### PR TITLE
Add cone and cylinder shape support

### DIFF
--- a/include/rt/Cone.h
+++ b/include/rt/Cone.h
@@ -1,0 +1,96 @@
+#pragma once
+#include "Hittable.h"
+#include <cmath>
+
+namespace rt {
+
+struct Cone : public Hittable {
+    Vec3 center;
+    Vec3 axis;      // axis pointing from base center to apex, normalized
+    double radius;  // base radius
+    double height;
+    int object_id;
+    int material_id;
+
+    Cone(const Vec3& c, const Vec3& ax, double r, double h,
+         int oid, int mid)
+        : center(c), axis(ax.normalized()), radius(r), height(h),
+          object_id(oid), material_id(mid) {}
+
+    bool hit(const Ray& r, double tmin, double tmax, HitRecord& rec) const override {
+        bool hit_any = false;
+        double closest = tmax;
+
+        // geometry helpers
+        Vec3 apex = center + axis * (height * 0.5);
+        Vec3 down = (-1) * axis; // direction from apex to base
+        double k = radius / height;
+
+        Vec3 oc = r.orig - apex;
+        double oc_dot_d = Vec3::dot(oc, down);
+        double d_dot_d = Vec3::dot(r.dir, down);
+
+        Vec3 oc_perp = oc - oc_dot_d * down;
+        Vec3 d_perp = r.dir - d_dot_d * down;
+
+        double A = Vec3::dot(d_perp, d_perp) - k*k*d_dot_d*d_dot_d;
+        double B = 2*Vec3::dot(d_perp, oc_perp) - 2*k*k*d_dot_d*oc_dot_d;
+        double C = Vec3::dot(oc_perp, oc_perp) - k*k*oc_dot_d*oc_dot_d;
+
+        double disc = B*B - 4*A*C;
+        if (disc >= 0) {
+            double sqrtD = std::sqrt(disc);
+            double roots[2] = {(-B - sqrtD)/(2*A), (-B + sqrtD)/(2*A)};
+            for (double root : roots) {
+                if (root < tmin || root > closest) continue;
+                double y = oc_dot_d + root*d_dot_d; // distance from apex along axis (down)
+                if (y < 0 || y > height) continue; // outside cone bounds
+                Vec3 p = r.at(root);
+                double ax_dist = y;
+                Vec3 x_parallel = down * ax_dist;
+                Vec3 x_perp = (oc + root*r.dir) - x_parallel;
+                Vec3 normal = (x_perp - (k*k*ax_dist)*down).normalized();
+                rec.t = root;
+                rec.p = p;
+                rec.object_id = object_id;
+                rec.material_id = material_id;
+                rec.set_face_normal(r, normal);
+                closest = root;
+                hit_any = true;
+            }
+        }
+
+        // base cap
+        Vec3 base_center = center - axis * (height * 0.5);
+        double denom = Vec3::dot(r.dir, (-1)*axis);
+        if (std::fabs(denom) > 1e-9) {
+            double t = Vec3::dot(base_center - r.orig, (-1)*axis) / denom;
+            if (t >= tmin && t <= closest) {
+                Vec3 p = r.at(t);
+                if ((p - base_center).length_squared() <= radius*radius) {
+                    rec.t = t;
+                    rec.p = p;
+                    rec.object_id = object_id;
+                    rec.material_id = material_id;
+                    rec.set_face_normal(r, (-1)*axis);
+                    closest = t;
+                    hit_any = true;
+                }
+            }
+        }
+
+        return hit_any;
+    }
+
+    bool bounding_box(AABB& out) const override {
+        Vec3 ax = axis * (height * 0.5);
+        Vec3 ex(radius, radius, radius);
+        Vec3 min = center - ax - ex;
+        Vec3 max = center + ax + ex;
+        out = AABB(min, max);
+        return true;
+    }
+};
+
+} // namespace rt
+

--- a/include/rt/Cylinder.h
+++ b/include/rt/Cylinder.h
@@ -18,7 +18,9 @@ struct Cylinder : public Hittable {
           object_id(oid), material_id(mid) {}
 
     bool hit(const Ray& r, double tmin, double tmax, HitRecord& rec) const override {
-        // przekształcamy promień do układu osi cylindra
+        bool hit_any = false;
+        double closest = tmax;
+
         Vec3 oc = r.orig - center;
         double d_dot_a = Vec3::dot(r.dir, axis);
         double oc_dot_a = Vec3::dot(oc, axis);
@@ -31,29 +33,65 @@ struct Cylinder : public Hittable {
         double C = Vec3::dot(oc_perp, oc_perp) - radius*radius;
 
         double disc = B*B - 4*A*C;
-        if (disc < 0) return false;
-
-        double sqrtD = std::sqrt(disc);
-        double root = (-B - sqrtD) / (2*A);
-        if (root < tmin || root > tmax) {
-            root = (-B + sqrtD) / (2*A);
-            if (root < tmin || root > tmax) return false;
+        if (disc >= 0) {
+            double sqrtD = std::sqrt(disc);
+            double roots[2] = {(-B - sqrtD)/(2*A), (-B + sqrtD)/(2*A)};
+            for (double root : roots) {
+                if (root < tmin || root > closest) continue;
+                double s = oc_dot_a + root*d_dot_a;
+                if (s < -height/2 || s > height/2) continue;
+                Vec3 p = r.at(root);
+                Vec3 proj = center + axis*s;
+                Vec3 outward = (p - proj).normalized();
+                rec.t = root;
+                rec.p = p;
+                rec.object_id = object_id;
+                rec.material_id = material_id;
+                rec.set_face_normal(r, outward);
+                closest = root;
+                hit_any = true;
+            }
         }
 
-        double s = oc_dot_a + root*d_dot_a;
-        if (s < -height/2 || s > height/2) {
-            return false; // poza zakresem wysokości
+        // caps
+        Vec3 top_center = center + axis*(height/2);
+        Vec3 bottom_center = center - axis*(height/2);
+
+        double denom_top = Vec3::dot(r.dir, axis);
+        if (std::fabs(denom_top) > 1e-9) {
+            double t = Vec3::dot(top_center - r.orig, axis) / denom_top;
+            if (t >= tmin && t <= closest) {
+                Vec3 p = r.at(t);
+                if ((p - top_center).length_squared() <= radius*radius) {
+                    rec.t = t;
+                    rec.p = p;
+                    rec.object_id = object_id;
+                    rec.material_id = material_id;
+                    rec.set_face_normal(r, axis);
+                    closest = t;
+                    hit_any = true;
+                }
+            }
         }
 
-        rec.t = root;
-        rec.p = r.at(root);
-        rec.object_id = object_id;
-        rec.material_id = material_id;
+        double denom_bot = Vec3::dot(r.dir, (-1)*axis);
+        if (std::fabs(denom_bot) > 1e-9) {
+            double t = Vec3::dot(bottom_center - r.orig, (-1)*axis) / denom_bot;
+            if (t >= tmin && t <= closest) {
+                Vec3 p = r.at(t);
+                if ((p - bottom_center).length_squared() <= radius*radius) {
+                    rec.t = t;
+                    rec.p = p;
+                    rec.object_id = object_id;
+                    rec.material_id = material_id;
+                    rec.set_face_normal(r, (-1)*axis);
+                    closest = t;
+                    hit_any = true;
+                }
+            }
+        }
 
-        Vec3 proj = center + axis*s;
-        Vec3 outward = (rec.p - proj).normalized();
-        rec.set_face_normal(r, outward);
-        return true;
+        return hit_any;
     }
 
     bool bounding_box(AABB& out) const override {

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -1,6 +1,8 @@
 #include "rt/Parser.h"
 #include "rt/Sphere.h"
 #include "rt/Plane.h"
+#include "rt/Cylinder.h"
+#include "rt/Cone.h"
 
 #include <fstream>
 #include <sstream>
@@ -113,7 +115,7 @@ bool Parser::parse_rt_file(const std::string& path,
             }
         } else if (id == "pl") {
             std::string s_p, s_n, s_rgb;
-            iss >> s_p >> adws_n >> s_rgb;
+            iss >> s_p >> s_n >> s_rgb;
             Vec3 p, n, rgb;
             if (parse_triple(s_p, p) && parse_triple(s_n, n) && parse_triple(s_rgb, rgb)) {
                 auto pl = std::make_shared<Plane>(p, n, oid++, mid);
@@ -122,8 +124,34 @@ bool Parser::parse_rt_file(const std::string& path,
                 outScene.objects.push_back(pl);
                 ++mid;
             }
+        } else if (id == "cy") {
+            std::string s_pos, s_dir, s_d, s_h, s_rgb;
+            iss >> s_pos >> s_dir >> s_d >> s_h >> s_rgb;
+            Vec3 c, dir, rgb; double d = 1.0, h = 1.0;
+            if (parse_triple(s_pos, c) && parse_triple(s_dir, dir)
+                && to_double(s_d, d) && to_double(s_h, h)
+                && parse_triple(s_rgb, rgb)) {
+                auto cy = std::make_shared<Cylinder>(c, dir, d/2.0, h, oid++, mid);
+                materials.emplace_back();
+                materials.back().color = rgb_to_unit(rgb);
+                outScene.objects.push_back(cy);
+                ++mid;
+            }
+        } else if (id == "co") {
+            std::string s_pos, s_dir, s_d, s_h, s_rgb;
+            iss >> s_pos >> s_dir >> s_d >> s_h >> s_rgb;
+            Vec3 c, dir, rgb; double d = 1.0, h = 1.0;
+            if (parse_triple(s_pos, c) && parse_triple(s_dir, dir)
+                && to_double(s_d, d) && to_double(s_h, h)
+                && parse_triple(s_rgb, rgb)) {
+                auto co = std::make_shared<Cone>(c, dir, d/2.0, h, oid++, mid);
+                materials.emplace_back();
+                materials.back().color = rgb_to_unit(rgb);
+                outScene.objects.push_back(co);
+                ++mid;
+            }
         }
-        // TODO: cy, co, textures...
+        // TODO: textures...
     }
 
     outCamera = Camera(cam_pos, cam_pos + cam_dir, fov, double(width)/double(height));


### PR DESCRIPTION
## Summary
- implement closed cylinder intersections and bounding boxes
- add cone primitive with cap and intersection logic
- extend parser to build cylinders and cones from scene files

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68a88093a7f0832fad1ea725b69d74d5