### PR TITLE
Display image in window with SDL2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,5 +18,6 @@ add_executable(minirt
 )
 
 find_package(Threads REQUIRED)
+find_package(SDL2 REQUIRED CONFIG)
 target_include_directories(minirt PRIVATE include)
-target_link_libraries(minirt PRIVATE Threads::Threads)
+target_link_libraries(minirt PRIVATE Threads::Threads SDL2::SDL2)

--- a/include/rt/Renderer.h
+++ b/include/rt/Renderer.h
@@ -19,6 +19,8 @@ public:
     void render_ppm(const std::string& path,
                     const std::vector<Material>& mats,
                     const RenderSettings& rset);
+    void render_window(const std::vector<Material>& mats,
+                       const RenderSettings& rset);
 private:
     const Scene& scene;
     const Camera& cam;

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -4,6 +4,8 @@
 #include <fstream>
 #include <cmath>
 #include <algorithm>
+#include <SDL2/SDL.h>
+#include <iostream>
 
 namespace rt {
 
@@ -88,6 +90,121 @@ void Renderer::render_ppm(const std::string& path,
             out.put(r).put(g).put(b);
         }
     }
+}
+
+void Renderer::render_window(const std::vector<Material>& mats,
+                             const RenderSettings& rset)
+{
+    const int W = rset.width;
+    const int H = rset.height;
+    const int T = (rset.threads > 0)
+                    ? rset.threads
+                    : (std::thread::hardware_concurrency()
+                        ? (int)std::thread::hardware_concurrency()
+                        : 8);
+
+    std::vector<Vec3> framebuffer(W * H);
+    std::atomic<int> next_row{0};
+
+    auto worker = [&]() {
+        HitRecord rec;
+        for (;;) {
+            int y = next_row.fetch_add(1);
+            if (y >= H) break;
+            for (int x = 0; x < W; ++x) {
+                double u = (x + 0.5) / W;
+                double v = (y + 0.5) / H;
+                Ray r = cam.ray_through(u, v);
+                Vec3 col(0,0,0);
+                if (scene.hit(r, 1e-4, 1e9, rec)) {
+                    const Material& m = mats[rec.material_id];
+                    Vec3 eye = (cam.origin - rec.p).normalized();
+                    Vec3 base = m.color;
+                    Vec3 sum( base.x*scene.ambient.color.x * scene.ambient.intensity,
+                              base.y*scene.ambient.color.y * scene.ambient.intensity,
+                              base.z*scene.ambient.color.z * scene.ambient.intensity );
+                    for (const auto& L : scene.lights) {
+                        if (in_shadow(scene, rec.p, L.position)) continue;
+                        Vec3 ldir = (L.position - rec.p).normalized();
+                        double diff = std::max(0.0, Vec3::dot(rec.normal, ldir));
+                        Vec3 h = (ldir + eye).normalized();
+                        double spec = std::pow(std::max(0.0, Vec3::dot(rec.normal, h)), m.specular_exp) * m.specular_k;
+                        sum += Vec3(base.x*L.color.x*L.intensity*diff + L.color.x*spec,
+                                    base.y*L.color.y*L.intensity*diff + L.color.y*spec,
+                                    base.z*L.color.z*L.intensity*diff + L.color.z*spec);
+                    }
+                    col = sum;
+                } else {
+                    col = Vec3(0.0, 0.0, 0.0);
+                }
+                framebuffer[y * W + x] = col;
+            }
+        }
+    };
+
+    std::vector<std::thread> pool;
+    pool.reserve(T);
+    for (int i = 0; i < T; ++i) pool.emplace_back(worker);
+    for (auto& th : pool) th.join();
+
+    std::vector<unsigned char> pixels(W * H * 3);
+    for (int y = 0; y < H; ++y) {
+        for (int x = 0; x < W; ++x) {
+            Vec3 c = framebuffer[y * W + x];
+            c.x = std::clamp(c.x, 0.0, 1.0);
+            c.y = std::clamp(c.y, 0.0, 1.0);
+            c.z = std::clamp(c.z, 0.0, 1.0);
+            pixels[(y * W + x) * 3 + 0] = static_cast<unsigned char>(std::lround(c.x * 255.0));
+            pixels[(y * W + x) * 3 + 1] = static_cast<unsigned char>(std::lround(c.y * 255.0));
+            pixels[(y * W + x) * 3 + 2] = static_cast<unsigned char>(std::lround(c.z * 255.0));
+        }
+    }
+
+    if (SDL_Init(SDL_INIT_VIDEO) != 0) {
+        std::cerr << "SDL_Init Error: " << SDL_GetError() << "\n";
+        return;
+    }
+    SDL_Window* win = SDL_CreateWindow("MiniRT", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, W, H, 0);
+    if (!win) {
+        std::cerr << "SDL_CreateWindow Error: " << SDL_GetError() << "\n";
+        SDL_Quit();
+        return;
+    }
+    SDL_Renderer* ren = SDL_CreateRenderer(win, -1, SDL_RENDERER_SOFTWARE);
+    if (!ren) {
+        std::cerr << "SDL_CreateRenderer Error: " << SDL_GetError() << "\n";
+        SDL_DestroyWindow(win);
+        SDL_Quit();
+        return;
+    }
+    SDL_Texture* tex = SDL_CreateTexture(ren, SDL_PIXELFORMAT_RGB24, SDL_TEXTUREACCESS_STREAMING, W, H);
+    if (!tex) {
+        std::cerr << "SDL_CreateTexture Error: " << SDL_GetError() << "\n";
+        SDL_DestroyRenderer(ren);
+        SDL_DestroyWindow(win);
+        SDL_Quit();
+        return;
+    }
+    SDL_UpdateTexture(tex, nullptr, pixels.data(), W * 3);
+
+    bool running = true;
+    SDL_Event e;
+    Uint32 start = SDL_GetTicks();
+    while (running) {
+        while (SDL_PollEvent(&e)) {
+            if (e.type == SDL_QUIT) running = false;
+        }
+        SDL_RenderClear(ren);
+        SDL_RenderCopy(ren, tex, nullptr, nullptr);
+        SDL_RenderPresent(ren);
+        if (SDL_GetTicks() - start > 5000) running = false;
+        SDL_Delay(16);
+    }
+
+    SDL_DestroyTexture(tex);
+    SDL_DestroyRenderer(ren);
+    SDL_DestroyWindow(win);
+    SDL_Quit();
 }
 
 } // namespace rt

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,15 +7,14 @@
 #include <thread>
 
 int main(int argc, char** argv) {
-    if (argc < 3) {
-        std::cerr << "Usage: minirt <scene.rt> <output.ppm> [width height threads]\n";
+    if (argc < 2) {
+        std::cerr << "Usage: minirt <scene.rt> [width height threads]\n";
         return 1;
     }
     std::string scene_path = argv[1];
-    std::string out_path = argv[2];
-    int width = (argc > 3) ? std::atoi(argv[3]) : 800;
-    int height = (argc > 4) ? std::atoi(argv[4]) : 600;
-    int threads = (argc > 5) ? std::atoi(argv[5]) : std::thread::hardware_concurrency();
+    int width = (argc > 2) ? std::atoi(argv[2]) : 800;
+    int height = (argc > 3) ? std::atoi(argv[3]) : 600;
+    int threads = (argc > 4) ? std::atoi(argv[4]) : std::thread::hardware_concurrency();
 
     rt::Scene scene;
     rt::Camera cam({0,0,-10}, {0,0,0}, 60.0, double(width)/double(height));
@@ -32,8 +31,7 @@ int main(int argc, char** argv) {
     rset.threads = threads > 0 ? threads : 8;
 
     rt::Renderer renderer(scene, cam);
-    renderer.render_ppm(out_path, mats, rset);
+    renderer.render_window(mats, rset);
 
-    std::cerr << "Wrote " << out_path << "\n";
     return 0;
 }


### PR DESCRIPTION
## Summary
- Add SDL2-based window renderer to show ray traced output directly
- Replace PPM export with in-memory framebuffer and timed window display
- Link against SDL2 and update CLI to drop output file argument

## Testing
- `cmake -S . -B build_temp`
- `cmake --build build_temp`
- `SDL_VIDEODRIVER=dummy ./build_temp/minirt scenes/test.rt 100 100 1`


------
https://chatgpt.com/codex/tasks/task_e_68a883646704832f8d65925a37304d78