### PR TITLE
Add interactive camera controls

### DIFF
--- a/include/rt/Camera.h
+++ b/include/rt/Camera.h
@@ -21,6 +21,23 @@ struct Camera {
         up = Vec3::cross(right, forward).normalized();
     }
 
+    void move(const Vec3& delta) {
+        origin += delta;
+    }
+
+    void rotate(double yaw, double pitch) {
+        Vec3 world_up(0,1,0);
+        auto rotate_vec = [](const Vec3& v, const Vec3& axis, double angle){
+            double c = std::cos(angle);
+            double s = std::sin(angle);
+            return v*c + Vec3::cross(axis, v)*s + axis*Vec3::dot(axis, v)*(1-c);
+        };
+        forward = rotate_vec(forward, world_up, yaw);
+        right = Vec3::cross(forward, world_up).normalized();
+        forward = rotate_vec(forward, right, pitch);
+        up = Vec3::cross(right, forward).normalized();
+    }
+
     Ray ray_through(double u, double v) const {
         double fov_rad = fov_deg * M_PI / 180.0;
         double half_h = std::tan(fov_rad * 0.5);

--- a/include/rt/Renderer.h
+++ b/include/rt/Renderer.h
@@ -15,7 +15,7 @@ struct RenderSettings {
 
 class Renderer {
 public:
-    Renderer(const Scene& s, const Camera& c);
+    Renderer(const Scene& s, Camera& c);
     void render_ppm(const std::string& path,
                     const std::vector<Material>& mats,
                     const RenderSettings& rset);
@@ -23,7 +23,7 @@ public:
                        const RenderSettings& rset);
 private:
     const Scene& scene;
-    const Camera& cam;
+    Camera& cam;
 };
 
 } // namespace rt

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -17,7 +17,7 @@ static bool in_shadow(const Scene& scene, const Vec3& p, const Vec3& light_pos) 
     return scene.hit(shadow_ray, 1e-4, dist_to_light - 1e-4, tmp);
 }
 
-Renderer::Renderer(const Scene& s, const Camera& c)
+Renderer::Renderer(const Scene& s, Camera& c)
     : scene(s), cam(c) {}
 
 void Renderer::render_ppm(const std::string& path,
@@ -103,63 +103,6 @@ void Renderer::render_window(const std::vector<Material>& mats,
                         ? (int)std::thread::hardware_concurrency()
                         : 8);
 
-    std::vector<Vec3> framebuffer(W * H);
-    std::atomic<int> next_row{0};
-
-    auto worker = [&]() {
-        HitRecord rec;
-        for (;;) {
-            int y = next_row.fetch_add(1);
-            if (y >= H) break;
-            for (int x = 0; x < W; ++x) {
-                double u = (x + 0.5) / W;
-                double v = (y + 0.5) / H;
-                Ray r = cam.ray_through(u, v);
-                Vec3 col(0,0,0);
-                if (scene.hit(r, 1e-4, 1e9, rec)) {
-                    const Material& m = mats[rec.material_id];
-                    Vec3 eye = (cam.origin - rec.p).normalized();
-                    Vec3 base = m.color;
-                    Vec3 sum( base.x*scene.ambient.color.x * scene.ambient.intensity,
-                              base.y*scene.ambient.color.y * scene.ambient.intensity,
-                              base.z*scene.ambient.color.z * scene.ambient.intensity );
-                    for (const auto& L : scene.lights) {
-                        if (in_shadow(scene, rec.p, L.position)) continue;
-                        Vec3 ldir = (L.position - rec.p).normalized();
-                        double diff = std::max(0.0, Vec3::dot(rec.normal, ldir));
-                        Vec3 h = (ldir + eye).normalized();
-                        double spec = std::pow(std::max(0.0, Vec3::dot(rec.normal, h)), m.specular_exp) * m.specular_k;
-                        sum += Vec3(base.x*L.color.x*L.intensity*diff + L.color.x*spec,
-                                    base.y*L.color.y*L.intensity*diff + L.color.y*spec,
-                                    base.z*L.color.z*L.intensity*diff + L.color.z*spec);
-                    }
-                    col = sum;
-                } else {
-                    col = Vec3(0.0, 0.0, 0.0);
-                }
-                framebuffer[y * W + x] = col;
-            }
-        }
-    };
-
-    std::vector<std::thread> pool;
-    pool.reserve(T);
-    for (int i = 0; i < T; ++i) pool.emplace_back(worker);
-    for (auto& th : pool) th.join();
-
-    std::vector<unsigned char> pixels(W * H * 3);
-    for (int y = 0; y < H; ++y) {
-        for (int x = 0; x < W; ++x) {
-            Vec3 c = framebuffer[y * W + x];
-            c.x = std::clamp(c.x, 0.0, 1.0);
-            c.y = std::clamp(c.y, 0.0, 1.0);
-            c.z = std::clamp(c.z, 0.0, 1.0);
-            pixels[(y * W + x) * 3 + 0] = static_cast<unsigned char>(std::lround(c.x * 255.0));
-            pixels[(y * W + x) * 3 + 1] = static_cast<unsigned char>(std::lround(c.y * 255.0));
-            pixels[(y * W + x) * 3 + 2] = static_cast<unsigned char>(std::lround(c.z * 255.0));
-        }
-    }
-
     if (SDL_Init(SDL_INIT_VIDEO) != 0) {
         std::cerr << "SDL_Init Error: " << SDL_GetError() << "\n";
         return;
@@ -185,20 +128,93 @@ void Renderer::render_window(const std::vector<Material>& mats,
         SDL_Quit();
         return;
     }
-    SDL_UpdateTexture(tex, nullptr, pixels.data(), W * 3);
 
-    bool running = true;
+    SDL_SetRelativeMouseMode(SDL_TRUE);
+
+    std::vector<Vec3> framebuffer(W * H);
+    std::vector<unsigned char> pixels(W * H * 3);
     SDL_Event e;
-    Uint32 start = SDL_GetTicks();
+    bool running = true;
+    Uint32 last = SDL_GetTicks();
+
     while (running) {
+        Uint32 now = SDL_GetTicks();
+        double dt = (now - last) / 1000.0;
+        last = now;
+
         while (SDL_PollEvent(&e)) {
             if (e.type == SDL_QUIT) running = false;
+            else if (e.type == SDL_MOUSEMOTION) {
+                double sens = 0.002;
+                cam.rotate(-e.motion.xrel * sens, -e.motion.yrel * sens);
+            }
         }
+
+        const Uint8* state = SDL_GetKeyboardState(nullptr);
+        double speed = 5.0 * dt;
+        if (state[SDL_SCANCODE_W]) cam.move(cam.forward * speed);
+        if (state[SDL_SCANCODE_S]) cam.move(cam.forward * -speed);
+        if (state[SDL_SCANCODE_A]) cam.move(cam.right * -speed);
+        if (state[SDL_SCANCODE_D]) cam.move(cam.right * speed);
+
+        std::atomic<int> next_row{0};
+        auto worker = [&]() {
+            HitRecord rec;
+            for (;;) {
+                int y = next_row.fetch_add(1);
+                if (y >= H) break;
+                for (int x = 0; x < W; ++x) {
+                    double u = (x + 0.5) / W;
+                    double v = (y + 0.5) / H;
+                    Ray r = cam.ray_through(u, v);
+                    Vec3 col(0,0,0);
+                    if (scene.hit(r, 1e-4, 1e9, rec)) {
+                        const Material& m = mats[rec.material_id];
+                        Vec3 eye = (cam.origin - rec.p).normalized();
+                        Vec3 base = m.color;
+                        Vec3 sum( base.x*scene.ambient.color.x * scene.ambient.intensity,
+                                  base.y*scene.ambient.color.y * scene.ambient.intensity,
+                                  base.z*scene.ambient.color.z * scene.ambient.intensity );
+                        for (const auto& L : scene.lights) {
+                            if (in_shadow(scene, rec.p, L.position)) continue;
+                            Vec3 ldir = (L.position - rec.p).normalized();
+                            double diff = std::max(0.0, Vec3::dot(rec.normal, ldir));
+                            Vec3 h = (ldir + eye).normalized();
+                            double spec = std::pow(std::max(0.0, Vec3::dot(rec.normal, h)), m.specular_exp) * m.specular_k;
+                            sum += Vec3(base.x*L.color.x*L.intensity*diff + L.color.x*spec,
+                                        base.y*L.color.y*L.intensity*diff + L.color.y*spec,
+                                        base.z*L.color.z*L.intensity*diff + L.color.z*spec);
+                        }
+                        col = sum;
+                    } else {
+                        col = Vec3(0.0, 0.0, 0.0);
+                    }
+                    framebuffer[y * W + x] = col;
+                }
+            }
+        };
+
+        std::vector<std::thread> pool;
+        pool.reserve(T);
+        for (int i = 0; i < T; ++i) pool.emplace_back(worker);
+        for (auto& th : pool) th.join();
+
+        for (int y = 0; y < H; ++y) {
+            for (int x = 0; x < W; ++x) {
+                Vec3 c = framebuffer[y * W + x];
+                c.x = std::clamp(c.x, 0.0, 1.0);
+                c.y = std::clamp(c.y, 0.0, 1.0);
+                c.z = std::clamp(c.z, 0.0, 1.0);
+                pixels[(y * W + x) * 3 + 0] = static_cast<unsigned char>(std::lround(c.x * 255.0));
+                pixels[(y * W + x) * 3 + 1] = static_cast<unsigned char>(std::lround(c.y * 255.0));
+                pixels[(y * W + x) * 3 + 2] = static_cast<unsigned char>(std::lround(c.z * 255.0));
+            }
+        }
+
+        SDL_UpdateTexture(tex, nullptr, pixels.data(), W * 3);
         SDL_RenderClear(ren);
         SDL_RenderCopy(ren, tex, nullptr, nullptr);
         SDL_RenderPresent(ren);
-        if (SDL_GetTicks() - start > 5000) running = false;
-        SDL_Delay(16);
     }
 
     SDL_DestroyTexture(tex);


### PR DESCRIPTION
## Summary
- Allow camera to translate and rotate with new `move` and `rotate` methods.
- Refactor renderer window to handle mouse look and WASD movement.
- Use relative mouse mode for first-person navigation.

## Testing
- `cmake .. && make -j4`

------
https://chatgpt.com/codex/tasks/task_e_68a885ca6940832fb6b38fea3d167f50