### PR TITLE
Add beam object with glowing cylinder

### DIFF
--- a/include/rt/Beam.h
+++ b/include/rt/Beam.h
@@ -1,0 +1,17 @@
+#pragma once
+#include "Cylinder.h"
+
+namespace rt {
+
+struct Beam : public Cylinder {
+    Beam(const Vec3& origin,
+         const Vec3& dir,
+         double radius,
+         double length,
+         int oid,
+         int mid)
+        : Cylinder(origin + dir.normalized() * (length * 0.5),
+                   dir, radius, length, oid, mid) {}
+};
+
+} // namespace rt

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -3,11 +3,14 @@
 #include "rt/Plane.h"
 #include "rt/Cylinder.h"
 #include "rt/Cone.h"
+#include "rt/Beam.h"
 
 #include <fstream>
 #include <sstream>
 #include <charconv>
 #include <string_view>
+#include <cmath>
+#include <algorithm>
 
 namespace {
 
@@ -135,6 +138,28 @@ bool Parser::parse_rt_file(const std::string& path,
                 materials.emplace_back();
                 materials.back().color = rgb_to_unit(rgb);
                 outScene.objects.push_back(cy);
+                ++mid;
+            }
+        } else if (id == "bm") {
+            std::string s_pos, s_dir, s_rgb, s_g, s_L;
+            iss >> s_pos >> s_dir >> s_rgb >> s_g >> s_L;
+            Vec3 o, dir, rgb; double g = 0.1, L = 1.0;
+            if (parse_triple(s_pos, o) && parse_triple(s_dir, dir)
+                && parse_triple(s_rgb, rgb) && to_double(s_g, g)
+                && to_double(s_L, L)) {
+                auto bm = std::make_shared<Beam>(o, dir, g, L, oid++, mid);
+                materials.emplace_back();
+                Vec3 unit = rgb_to_unit(rgb);
+                materials.back().color = unit;
+                outScene.objects.push_back(bm);
+                Vec3 dirN = dir.normalized();
+                int nlights = std::max(1, static_cast<int>(std::ceil(L)));
+                double inten = 0.1 / nlights;
+                for (int i = 0; i < nlights; ++i) {
+                    double t = (i + 0.5) / nlights;
+                    Vec3 lp = o + dirN * (L * t);
+                    outScene.lights.emplace_back(lp, unit, inten);
+                }
                 ++mid;
             }
         } else if (id == "co") {


### PR DESCRIPTION
## Summary
- Add Beam class derived from Cylinder for finite visible rays
- Parse `bm` scene entries and distribute faint colored lights along the beam length to simulate afterglow

## Testing
- `apt-get install -y libsdl2-dev`
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68ac6c1db590832f9cf5e82b11a85dc3