### PR TITLE
Add beam object with glowing cylinder

### DIFF
--- a/include/rt/Beam.h
+++ b/include/rt/Beam.h
@@ -1,0 +1,19 @@
+#pragma once
+#include "Cylinder.h"
+
+namespace rt {
+
+struct Beam : public Cylinder {
+    Beam(const Vec3& origin,
+         const Vec3& dir,
+         double radius,
+         double length,
+         int oid,
+         int mid)
+        : Cylinder(origin + dir.normalized() * (length * 0.5),
+                   dir, radius, length, oid, mid) {}
+
+    bool is_beam() const override { return true; }
+};
+
+} // namespace rt

--- a/include/rt/Cylinder.h
+++ b/include/rt/Cylinder.h
@@ -47,10 +47,11 @@ struct Cylinder : public Hittable {
                 rec.p = p;
                 rec.object_id = object_id;
                 rec.material_id = material_id;
+                rec.beam_ratio = (s + height/2) / height;
                 rec.set_face_normal(r, outward);
                 closest = root;
                 hit_any = true;
-            }
+                }
         }
 
         // caps
@@ -67,6 +68,7 @@ struct Cylinder : public Hittable {
                     rec.p = p;
                     rec.object_id = object_id;
                     rec.material_id = material_id;
+                    rec.beam_ratio = 1.0;
                     rec.set_face_normal(r, axis);
                     closest = t;
                     hit_any = true;
@@ -84,6 +86,7 @@ struct Cylinder : public Hittable {
                     rec.p = p;
                     rec.object_id = object_id;
                     rec.material_id = material_id;
+                    rec.beam_ratio = 0.0;
                     rec.set_face_normal(r, (-1)*axis);
                     closest = t;
                     hit_any = true;

--- a/include/rt/Hittable.h
+++ b/include/rt/Hittable.h
@@ -16,6 +16,7 @@ struct HitRecord {
     int object_id;
     int material_id;
     bool front_face;
+    double beam_ratio = 0.0;
     void set_face_normal(const Ray& r, const Vec3& outward_normal) {
         front_face = Vec3::dot(r.dir, outward_normal) < 0;
         normal = front_face ? outward_normal : outward_normal * -1.0;
@@ -26,6 +27,7 @@ struct Hittable {
     virtual ~Hittable() = default;
     virtual bool hit(const Ray& r, double tmin, double tmax, HitRecord& rec) const = 0;
     virtual bool bounding_box(AABB& out) const = 0;
+    virtual bool is_beam() const { return false; }
 };
 
 using HittablePtr = std::shared_ptr<Hittable>;

--- a/include/rt/material.h
+++ b/include/rt/material.h
@@ -10,6 +10,7 @@ struct Material {
     double specular_exp = 50.0;
     double specular_k = 0.5;
     bool mirror = false;
+    bool random_alpha = false;
 };
 
 inline Vec3 phong(const Material& m, const Ambient& ambient,

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -3,11 +3,14 @@
 #include "rt/Plane.h"
 #include "rt/Cylinder.h"
 #include "rt/Cone.h"
+#include "rt/Beam.h"
 
 #include <fstream>
 #include <sstream>
 #include <charconv>
 #include <string_view>
+#include <cmath>
+#include <algorithm>
 
 namespace {
 
@@ -137,6 +140,21 @@ bool Parser::parse_rt_file(const std::string& path,
                 outScene.objects.push_back(cy);
                 ++mid;
             }
+        } else if (id == "bm") {
+            std::string s_pos, s_dir, s_rgb, s_g, s_L;
+            iss >> s_pos >> s_dir >> s_rgb >> s_g >> s_L;
+            Vec3 o, dir, rgb; double g = 0.1, L = 1.0;
+            if (parse_triple(s_pos, o) && parse_triple(s_dir, dir)
+                && parse_triple(s_rgb, rgb) && to_double(s_g, g)
+                && to_double(s_L, L)) {
+                auto bm = std::make_shared<Beam>(o, dir, g, L, oid++, mid);
+                materials.emplace_back();
+                Vec3 unit = rgb_to_unit(rgb);
+                materials.back().color = unit;
+                materials.back().random_alpha = true;
+                outScene.objects.push_back(bm);
+                ++mid;
+            }
         } else if (id == "co") {
             std::string s_pos, s_dir, s_d, s_h, s_rgb;
             iss >> s_pos >> s_dir >> s_d >> s_h >> s_rgb;
@@ -152,6 +170,37 @@ bool Parser::parse_rt_file(const std::string& path,
             }
         }
         // TODO: textures...
+    }
+
+    // Trim beams so they stop at the first blocking object and add faint lights
+    for (auto& obj : outScene.objects) {
+        if (!obj->is_beam()) continue;
+        Beam* bm = static_cast<Beam*>(obj.get());
+        Vec3 start = bm->center - bm->axis * (bm->height * 0.5);
+        Ray forward(start, bm->axis);
+        HitRecord tmp;
+        double closest = bm->height;
+        for (auto& other : outScene.objects) {
+            if (other.get() == bm) continue;
+            if (other->hit(forward, 1e-4, closest, tmp)) {
+                closest = tmp.t;
+            }
+        }
+        if (closest < bm->height) {
+            bm->height = closest;
+            bm->center = start + bm->axis * (closest * 0.5);
+        }
+
+        // recompute start of the (possibly truncated) beam
+        start = bm->center - bm->axis * (bm->height * 0.5);
+        // sprinkle a few point lights along its length for afterglow
+        const Material& m = materials[bm->material_id];
+        int segments = std::max(1, (int)std::ceil(bm->height / std::max(0.1, bm->radius * 2.0)));
+        double step = bm->height / segments;
+        for (int i = 0; i < segments; ++i) {
+            Vec3 pos = start + bm->axis * (step * (i + 0.5));
+            outScene.lights.emplace_back(pos, m.color, 0.05);
+        }
     }
 
     outCamera = Camera(cam_pos, cam_pos + cam_dir, fov, double(width)/double(height));

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -4,6 +4,7 @@
 #include <fstream>
 #include <cmath>
 #include <algorithm>
+#include <random>
 #include <SDL2/SDL.h>
 #include <iostream>
 
@@ -36,6 +37,8 @@ void Renderer::render_ppm(const std::string& path,
     std::atomic<int> next_row{0};
 
     auto worker = [&]() {
+        std::mt19937 rng(std::random_device{}());
+        std::uniform_real_distribution<double> dist(0.0, 1.0);
         HitRecord rec;
         for (;;) {
             int y = next_row.fetch_add(1);
@@ -61,6 +64,11 @@ void Renderer::render_ppm(const std::string& path,
                         sum += Vec3(base.x*L.color.x*L.intensity*diff + L.color.x*spec,
                                     base.y*L.color.y*L.intensity*diff + L.color.y*spec,
                                     base.z*L.color.z*L.intensity*diff + L.color.z*spec);
+                    }
+                    if (m.random_alpha) {
+                        double tpos = std::clamp(rec.beam_ratio, 0.0, 1.0);
+                        double alpha = (1.0 - tpos) * std::pow(dist(rng), tpos);
+                        sum *= alpha;
                     }
                     col = sum;
                 } else {
@@ -161,6 +169,8 @@ void Renderer::render_window(const std::vector<Material>& mats,
 
         std::atomic<int> next_row{0};
         auto worker = [&]() {
+            std::mt19937 rng(std::random_device{}());
+            std::uniform_real_distribution<double> dist(0.0, 1.0);
             HitRecord rec;
             for (;;) {
                 int y = next_row.fetch_add(1);
@@ -186,6 +196,11 @@ void Renderer::render_window(const std::vector<Material>& mats,
                             sum += Vec3(base.x*L.color.x*L.intensity*diff + L.color.x*spec,
                                         base.y*L.color.y*L.intensity*diff + L.color.y*spec,
                                         base.z*L.color.z*L.intensity*diff + L.color.z*spec);
+                        }
+                        if (m.random_alpha) {
+                            double tpos = std::clamp(rec.beam_ratio, 0.0, 1.0);
+                            double alpha = (1.0 - tpos) * std::pow(dist(rng), tpos);
+                            sum *= alpha;
                         }
                         col = sum;
                     } else {


### PR DESCRIPTION
## Summary
- Add `is_beam` identifier to hittables and override in `Beam`
- Clip beams against scene geometry by shortening them to the first hit along their axis
- Sprinkle faint point lights along the remaining beam segment for a subtle glow

## Testing
- `sudo apt-get install -y libsdl2-dev`
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68ac6c1db590832f9cf5e82b11a85dc3