### PR TITLE
Refactor beam into ray-like visible segment

### DIFF
--- a/include/rt/Beam.hpp
+++ b/include/rt/Beam.hpp
@@ -1,13 +1,22 @@
 #pragma once
-#include "Cylinder.hpp"
+#include "Hittable.hpp"
+#include "Ray.hpp"
 
 namespace rt
 {
-struct Beam : public Cylinder
+struct Beam : public Hittable
 {
+  Ray path;
+  double radius;
+  double length;
+  int object_id;
+  int material_id;
+
   Beam(const Vec3 &origin, const Vec3 &dir, double radius, double length,
        int oid, int mid);
 
+  bool hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const override;
+  bool bounding_box(AABB &out) const override;
   bool is_beam() const override;
 };
 

--- a/src/Beam.cpp
+++ b/src/Beam.cpp
@@ -1,12 +1,85 @@
 #include "rt/Beam.hpp"
+#include <algorithm>
+#include <cmath>
 
 namespace rt
 {
-Beam::Beam(const Vec3 &origin, const Vec3 &dir, double radius, double length,
-           int oid, int mid)
-    : Cylinder(origin + dir.normalized() * (length * 0.5), dir, radius, length,
-               oid, mid)
+Beam::Beam(const Vec3 &origin, const Vec3 &dir, double r, double len, int oid,
+           int mid)
+    : path(origin, dir.normalized()), radius(r), length(len), object_id(oid),
+      material_id(mid)
 {
+}
+
+bool Beam::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
+{
+  Vec3 u = r.dir;
+  Vec3 v = path.dir;
+  Vec3 w0 = r.orig - path.orig;
+  double a = Vec3::dot(u, u);
+  double b = Vec3::dot(u, v);
+  double c = Vec3::dot(v, v);
+  double d = Vec3::dot(u, w0);
+  double e = Vec3::dot(v, w0);
+  double denom = a * c - b * b;
+
+  double sc, tc;
+  if (std::fabs(denom) < 1e-9)
+  {
+    sc = -d / a;
+    tc = (a * e - b * d) / (a * c);
+  }
+  else
+  {
+    sc = (b * e - c * d) / denom;
+    tc = (a * e - b * d) / denom;
+  }
+
+  if (sc < tmin || sc > tmax)
+    return false;
+  if (tc < 0.0 || tc > length)
+    return false;
+
+  Vec3 pr = r.at(sc);
+  Vec3 pb = path.at(tc);
+  Vec3 diff = pr - pb;
+  double dist2 = diff.length_squared();
+  if (dist2 > radius * radius)
+    return false;
+
+  Vec3 outward;
+  if (dist2 > 1e-12)
+  {
+    outward = diff.normalized();
+  }
+  else
+  {
+    outward = Vec3::cross(path.dir, Vec3(1, 0, 0));
+    if (outward.length_squared() < 1e-12)
+      outward = Vec3::cross(path.dir, Vec3(0, 1, 0));
+    outward = outward.normalized();
+  }
+
+  rec.t = sc;
+  rec.p = pr;
+  rec.object_id = object_id;
+  rec.material_id = material_id;
+  rec.beam_ratio = tc / length;
+  rec.set_face_normal(r, outward);
+  return true;
+}
+
+bool Beam::bounding_box(AABB &out) const
+{
+  Vec3 start = path.orig;
+  Vec3 end = path.at(length);
+  Vec3 min(std::min(start.x, end.x), std::min(start.y, end.y),
+           std::min(start.z, end.z));
+  Vec3 max(std::max(start.x, end.x), std::max(start.y, end.y),
+           std::max(start.z, end.z));
+  Vec3 ex(radius, radius, radius);
+  out = AABB(min - ex, max + ex);
+  return true;
 }
 
 bool Beam::is_beam() const { return true; }

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -266,10 +266,9 @@ bool Parser::parse_rt_file(const std::string &path, Scene &outScene,
     if (!obj->is_beam())
       continue;
     Beam *bm = static_cast<Beam *>(obj.get());
-    Vec3 start = bm->center - bm->axis * (bm->height * 0.5);
-    Ray forward(start, bm->axis);
+    Ray forward(bm->path.orig, bm->path.dir);
     HitRecord tmp;
-    double closest = bm->height;
+    double closest = bm->length;
     for (auto &other : outScene.objects)
     {
       if (other.get() == bm)
@@ -279,10 +278,9 @@ bool Parser::parse_rt_file(const std::string &path, Scene &outScene,
         closest = tmp.t;
       }
     }
-    if (closest < bm->height)
+    if (closest < bm->length)
     {
-      bm->height = closest;
-      bm->center = start + bm->axis * (closest * 0.5);
+      bm->length = closest;
     }
   }
 


### PR DESCRIPTION
## Summary
- Reimplement `Beam` as a ray-based hittable with explicit path, radius, and length
- Provide custom intersection and bounding-box logic for the new ray-like beam
- Adjust scene parser to trim beams using the updated representation

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68af3a462f80832f88c4ec0c74099325