### PR TITLE
Prevent object overlap during movement

### DIFF
--- a/include/rt/AABB.hpp
+++ b/include/rt/AABB.hpp
@@ -15,6 +15,7 @@ struct AABB
   AABB(const Vec3 &a, const Vec3 &b);
 
   bool hit(const Ray &r, double tmin, double tmax) const;
+  bool intersects(const AABB &other) const;
   static AABB surrounding_box(const AABB &box0, const AABB &box1);
 };
 } // namespace rt

--- a/include/rt/Scene.hpp
+++ b/include/rt/Scene.hpp
@@ -19,6 +19,8 @@ struct Scene
   void update_beams(const std::vector<Material> &mats);
   void build_bvh();
   bool hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const;
+  bool try_translate(int obj_id, const Vec3 &delta);
+  bool try_rotate(int obj_id, const Vec3 &axis, double angle);
 };
 
 } // namespace rt

--- a/src/AABB.cpp
+++ b/src/AABB.cpp
@@ -32,6 +32,13 @@ bool AABB::hit(const Ray &r, double tmin, double tmax) const
   return true;
 }
 
+bool AABB::intersects(const AABB &other) const
+{
+  return (max.x >= other.min.x && min.x <= other.max.x) &&
+         (max.y >= other.min.y && min.y <= other.max.y) &&
+         (max.z >= other.min.z && min.z <= other.max.z);
+}
+
 AABB AABB::surrounding_box(const AABB &box0, const AABB &box1)
 {
   Vec3 small(std::min(box0.min.x, box1.min.x), std::min(box0.min.y, box1.min.y),

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -326,10 +326,13 @@ void Renderer::render_window(std::vector<Material> &mats,
         double sens = 0.002;
         if (edit_mode && selected_obj != -1)
         {
-          scene.objects[selected_obj]->rotate(cam.up, -e.motion.xrel * sens);
-          scene.objects[selected_obj]->rotate(cam.right, -e.motion.yrel * sens);
-          scene.update_beams(mats);
-          scene.build_bvh();
+          bool changed = scene.try_rotate(selected_obj, cam.up, -e.motion.xrel * sens);
+          changed |= scene.try_rotate(selected_obj, cam.right, -e.motion.yrel * sens);
+          if (changed)
+          {
+            scene.update_beams(mats);
+            scene.build_bvh();
+          }
         }
         else
         {
@@ -339,9 +342,11 @@ void Renderer::render_window(std::vector<Material> &mats,
       else if (edit_mode && selected_obj != -1 && e.type == SDL_MOUSEWHEEL)
       {
         double step = e.wheel.y * 1.0;
-        scene.objects[selected_obj]->translate(cam.up * step);
-        scene.update_beams(mats);
-        scene.build_bvh();
+        if (scene.try_translate(selected_obj, cam.up * step))
+        {
+          scene.update_beams(mats);
+          scene.build_bvh();
+        }
       }
       else if (focused && e.type == SDL_KEYDOWN &&
                e.key.keysym.scancode == SDL_SCANCODE_ESCAPE)
@@ -363,9 +368,11 @@ void Renderer::render_window(std::vector<Material> &mats,
         move += cam.right * speed;
       if (move.length_squared() > 0)
       {
-        scene.objects[selected_obj]->translate(move);
-        scene.update_beams(mats);
-        scene.build_bvh();
+        if (scene.try_translate(selected_obj, move))
+        {
+          scene.update_beams(mats);
+          scene.build_bvh();
+        }
       }
     }
     else if (focused)

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -116,4 +116,58 @@ bool Scene::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
   return hit_any;
 }
 
+bool Scene::try_translate(int obj_id, const Vec3 &delta)
+{
+  if (obj_id < 0 || obj_id >= static_cast<int>(objects.size()))
+    return false;
+  objects[obj_id]->translate(delta);
+  AABB moved_box;
+  if (!objects[obj_id]->bounding_box(moved_box))
+    return true;
+  for (size_t i = 0; i < objects.size(); ++i)
+  {
+    if (static_cast<int>(i) == obj_id)
+      continue;
+    AABB other_box;
+    if (!objects[i]->bounding_box(other_box))
+      continue;
+    Vec3 size = other_box.max - other_box.min;
+    if (size.x > 1e5 || size.y > 1e5 || size.z > 1e5)
+      continue;
+    if (moved_box.intersects(other_box))
+    {
+      objects[obj_id]->translate(delta * -1.0);
+      return false;
+    }
+  }
+  return true;
+}
+
+bool Scene::try_rotate(int obj_id, const Vec3 &axis, double angle)
+{
+  if (obj_id < 0 || obj_id >= static_cast<int>(objects.size()))
+    return false;
+  objects[obj_id]->rotate(axis, angle);
+  AABB rotated_box;
+  if (!objects[obj_id]->bounding_box(rotated_box))
+    return true;
+  for (size_t i = 0; i < objects.size(); ++i)
+  {
+    if (static_cast<int>(i) == obj_id)
+      continue;
+    AABB other_box;
+    if (!objects[i]->bounding_box(other_box))
+      continue;
+    Vec3 size = other_box.max - other_box.min;
+    if (size.x > 1e5 || size.y > 1e5 || size.z > 1e5)
+      continue;
+    if (rotated_box.intersects(other_box))
+    {
+      objects[obj_id]->rotate(axis, -angle);
+      return false;
+    }
+  }
+  return true;
+}
+
 } // namespace rt


### PR DESCRIPTION
## Summary
- add AABB intersection helper
- block translations and rotations that would cause bounding box overlap
- integrate scene collision checks into editor controls

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68b162857290832f8d299d1319fbcda8