### PR TITLE
Fix beam hit to fill cylinder volume

### DIFF
--- a/src/Beam.cpp
+++ b/src/Beam.cpp
@@ -1,5 +1,4 @@
 #include "rt/Beam.hpp"
-#include <algorithm>
 #include <cmath>
 
 namespace rt
@@ -15,60 +14,94 @@ Beam::Beam(const Vec3 &origin, const Vec3 &dir, double r, double len, int oid,
 
 bool Beam::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
 {
-  Vec3 u = r.dir;
-  Vec3 v = path.dir;
-  Vec3 w0 = r.orig - path.orig;
-  double a = Vec3::dot(u, u);
-  double b = Vec3::dot(u, v);
-  double c = Vec3::dot(v, v);
-  double d = Vec3::dot(u, w0);
-  double e = Vec3::dot(v, w0);
-  double denom = a * c - b * b;
+  bool hit_any = false;
+  double closest = tmax;
 
-  double sc, tc;
-  if (std::fabs(denom) < 1e-9)
-  {
-    sc = -d / a;
-    tc = (a * e - b * d) / (a * c);
-  }
-  else
-  {
-    sc = (b * e - c * d) / denom;
-    tc = (a * e - b * d) / denom;
-  }
+  Vec3 axis = path.dir;
+  Vec3 oc = r.orig - path.orig;
 
-  if (sc < tmin || sc > tmax)
-    return false;
-  if (tc < 0.0 || tc > length)
-    return false;
+  double d_dot_a = Vec3::dot(r.dir, axis);
+  double oc_dot_a = Vec3::dot(oc, axis);
 
-  Vec3 pr = r.at(sc);
-  Vec3 pb = path.at(tc);
-  Vec3 diff = pr - pb;
-  double dist2 = diff.length_squared();
-  if (dist2 > radius * radius)
-    return false;
+  Vec3 d_perp = r.dir - d_dot_a * axis;
+  Vec3 oc_perp = oc - oc_dot_a * axis;
 
-  Vec3 outward;
-  if (dist2 > 1e-12)
+  double A = Vec3::dot(d_perp, d_perp);
+  double B = 2 * Vec3::dot(d_perp, oc_perp);
+  double C = Vec3::dot(oc_perp, oc_perp) - radius * radius;
+
+  double disc = B * B - 4 * A * C;
+  if (disc >= 0)
   {
-    outward = diff.normalized();
-  }
-  else
-  {
-    outward = Vec3::cross(path.dir, Vec3(1, 0, 0));
-    if (outward.length_squared() < 1e-12)
-      outward = Vec3::cross(path.dir, Vec3(0, 1, 0));
-    outward = outward.normalized();
+    double sqrtD = std::sqrt(disc);
+    double roots[2] = {(-B - sqrtD) / (2 * A), (-B + sqrtD) / (2 * A)};
+    for (double root : roots)
+    {
+      if (root < tmin || root > closest)
+        continue;
+      double s = oc_dot_a + root * d_dot_a;
+      if (s < 0.0 || s > length)
+        continue;
+      Vec3 p = r.at(root);
+      Vec3 proj = path.orig + axis * s;
+      Vec3 outward = (p - proj).normalized();
+      rec.t = root;
+      rec.p = p;
+      rec.object_id = object_id;
+      rec.material_id = material_id;
+      rec.beam_ratio = (start + s) / total_length;
+      rec.set_face_normal(r, outward);
+      closest = root;
+      hit_any = true;
+    }
   }
 
-  rec.t = sc;
-  rec.p = pr;
-  rec.object_id = object_id;
-  rec.material_id = material_id;
-  rec.beam_ratio = (start + tc) / total_length;
-  rec.set_face_normal(r, outward);
-  return true;
+  Vec3 start_center = path.orig;
+  Vec3 end_center = path.at(length);
+
+  double denom_start = Vec3::dot(r.dir, (-1) * axis);
+  if (std::fabs(denom_start) > 1e-9)
+  {
+    double t = Vec3::dot(start_center - r.orig, (-1) * axis) / denom_start;
+    if (t >= tmin && t <= closest)
+    {
+      Vec3 p = r.at(t);
+      if ((p - start_center).length_squared() <= radius * radius)
+      {
+        rec.t = t;
+        rec.p = p;
+        rec.object_id = object_id;
+        rec.material_id = material_id;
+        rec.beam_ratio = start / total_length;
+        rec.set_face_normal(r, (-1) * axis);
+        closest = t;
+        hit_any = true;
+      }
+    }
+  }
+
+  double denom_end = Vec3::dot(r.dir, axis);
+  if (std::fabs(denom_end) > 1e-9)
+  {
+    double t = Vec3::dot(end_center - r.orig, axis) / denom_end;
+    if (t >= tmin && t <= closest)
+    {
+      Vec3 p = r.at(t);
+      if ((p - end_center).length_squared() <= radius * radius)
+      {
+        rec.t = t;
+        rec.p = p;
+        rec.object_id = object_id;
+        rec.material_id = material_id;
+        rec.beam_ratio = (start + length) / total_length;
+        rec.set_face_normal(r, axis);
+        closest = t;
+        hit_any = true;
+      }
+    }
+  }
+
+  return hit_any;
 }
 
 bool Beam::bounding_box(AABB &out) const


### PR DESCRIPTION
## Summary
- compute full cylinder intersection for beams, including caps
- allow beams to render as solid volumes instead of hollow tubes

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68b19038f898832f8a89cabfe9e76a40