### PR TITLE
Add internal light to beam sources

### DIFF
--- a/include/rt/BeamSource.hpp
+++ b/include/rt/BeamSource.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "Beam.hpp"
 #include "Sphere.hpp"
+#include "HoledSphere.hpp"
 #include <memory>
 
 namespace rt
@@ -8,10 +9,11 @@ namespace rt
 struct BeamSource : public Sphere
 {
   Sphere mid;
-  Sphere inner;
+  std::shared_ptr<HoledSphere> inner;
   std::shared_ptr<Beam> beam;
-  BeamSource(const Vec3 &c, const Vec3 &dir, const std::shared_ptr<Beam> &bm,
-             int oid, int mat_big, int mat_mid, int mat_small);
+  BeamSource(const Vec3 &c, const std::shared_ptr<Beam> &bm,
+             const std::shared_ptr<HoledSphere> &inner, int oid, int mat_big,
+             int mat_mid);
   bool hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const override;
   bool bounding_box(AABB &out) const override { return Sphere::bounding_box(out); }
   void translate(const Vec3 &delta) override;

--- a/include/rt/HoledSphere.hpp
+++ b/include/rt/HoledSphere.hpp
@@ -1,0 +1,14 @@
+#pragma once
+#include "Sphere.hpp"
+
+namespace rt
+{
+struct HoledSphere : public Sphere
+{
+  Vec3 dir;
+  double hole_radius;
+  HoledSphere(const Vec3 &c, const Vec3 &dir, double r, int oid, int mid);
+  bool hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const override;
+  void rotate(const Vec3 &axis, double angle) override;
+};
+}

--- a/include/rt/light.hpp
+++ b/include/rt/light.hpp
@@ -1,6 +1,7 @@
 
 #pragma once
 #include "Vec3.hpp"
+#include <vector>
 
 namespace rt
 {
@@ -9,8 +10,11 @@ struct PointLight
   Vec3 position;
   Vec3 color;
   double intensity;
+  std::vector<int> ignore_ids;
+  int attached_id;
 
-  PointLight(const Vec3 &p, const Vec3 &c, double i);
+  PointLight(const Vec3 &p, const Vec3 &c, double i,
+             std::vector<int> ignore_ids = {}, int attached_id = -1);
 };
 
 struct Ambient

--- a/src/BeamSource.cpp
+++ b/src/BeamSource.cpp
@@ -3,12 +3,11 @@
 
 namespace rt
 {
-BeamSource::BeamSource(const Vec3 &c, const Vec3 &dir,
-                       const std::shared_ptr<Beam> &bm, int oid,
-                       int mat_big, int mat_mid, int mat_small)
+BeamSource::BeamSource(const Vec3 &c, const std::shared_ptr<Beam> &bm,
+                       const std::shared_ptr<HoledSphere> &in, int oid,
+                       int mat_big, int mat_mid)
     : Sphere(c, 0.6, oid, mat_big),
-      mid(c, 0.6 * 0.67, oid, mat_mid),
-      inner(c, 0.6 * 0.33, oid, mat_small), beam(bm)
+      mid(c, 0.6 * 0.67, oid, mat_mid), inner(in), beam(bm)
 {
 }
 
@@ -29,12 +28,6 @@ bool BeamSource::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) con
     closest = tmp.t;
     rec = tmp;
   }
-  if (inner.hit(r, tmin, closest, tmp))
-  {
-    hit_any = true;
-    closest = tmp.t;
-    rec = tmp;
-  }
   if (hit_any)
     rec.object_id = object_id;
   return hit_any;
@@ -44,7 +37,8 @@ void BeamSource::translate(const Vec3 &delta)
 {
   Sphere::translate(delta);
   mid.translate(delta);
-  inner.translate(delta);
+  if (inner)
+    inner->translate(delta);
   if (beam)
     beam->path.orig += delta;
 }
@@ -58,6 +52,8 @@ void BeamSource::rotate(const Vec3 &ax, double angle)
   };
   if (beam)
     beam->path.dir = rotate_vec(beam->path.dir, ax, angle).normalized();
+  if (inner)
+    inner->rotate(ax, angle);
 }
 
 } // namespace rt

--- a/src/HoledSphere.cpp
+++ b/src/HoledSphere.cpp
@@ -1,0 +1,31 @@
+#include "rt/HoledSphere.hpp"
+#include <cmath>
+
+namespace rt
+{
+HoledSphere::HoledSphere(const Vec3 &c, const Vec3 &d, double r, int oid, int mid)
+    : Sphere(c, r, oid, mid), dir(d.normalized()), hole_radius(r * 0.25)
+{
+}
+
+bool HoledSphere::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
+{
+  if (!Sphere::hit(r, tmin, tmax, rec))
+    return false;
+  Vec3 local = (rec.p - center) / radius;
+  double cos_cutoff = std::sqrt(1.0 - (hole_radius / radius) * (hole_radius / radius));
+  if (Vec3::dot(local, dir) >= cos_cutoff)
+    return false;
+  return true;
+}
+
+void HoledSphere::rotate(const Vec3 &ax, double angle)
+{
+  auto rotate_vec = [](const Vec3 &v, const Vec3 &axis, double ang) {
+    double c = std::cos(ang);
+    double s = std::sin(ang);
+    return v * c + Vec3::cross(axis, v) * s + axis * Vec3::dot(axis, v) * (1 - c);
+  };
+  dir = rotate_vec(dir, ax, angle).normalized();
+}
+} // namespace rt

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -1,6 +1,7 @@
 #include "rt/Parser.hpp"
 #include "rt/Beam.hpp"
 #include "rt/BeamSource.hpp"
+#include "rt/HoledSphere.hpp"
 #include "rt/Cube.hpp"
 #include "rt/Cone.hpp"
 #include "rt/Cylinder.hpp"
@@ -316,12 +317,19 @@ bool Parser::parse_rt_file(const std::string &path, Scene &outScene,
         materials.back().alpha = 1.0;
         int small_mat = mid++;
 
-        auto src = std::make_shared<BeamSource>(o, dir, bm, oid++, big_mat,
-                                                mid_mat, small_mat);
+        auto inner =
+            std::make_shared<HoledSphere>(o, dir, 0.6 * 0.33, oid++, small_mat);
+        auto src =
+            std::make_shared<BeamSource>(o, bm, inner, oid++, big_mat, mid_mat);
         src->movable = (s_move == "M");
         bm->source = src;
         outScene.objects.push_back(bm);
         outScene.objects.push_back(src);
+        outScene.objects.push_back(inner);
+        outScene.lights.emplace_back(
+            o, unit, 0.75,
+            std::vector<int>{bm->object_id, src->object_id},
+            src->object_id);
       }
     }
     else if (id == "co")

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -27,6 +27,9 @@ static bool in_shadow(const Scene &scene, const Vec3 &p, const PointLight &L)
       continue;
     if (obj->hit(shadow_ray, 1e-4, dist_to_light - 1e-4, tmp))
     {
+      if (std::find(L.ignore_ids.begin(), L.ignore_ids.end(), tmp.object_id) !=
+          L.ignore_ids.end())
+        continue;
       return true;
     }
   }
@@ -62,6 +65,9 @@ static Vec3 trace_ray(const Scene &scene, const std::vector<Material> &mats,
            col.z * scene.ambient.color.z * scene.ambient.intensity);
   for (const auto &L : scene.lights)
   {
+    if (std::find(L.ignore_ids.begin(), L.ignore_ids.end(), rec.object_id) !=
+        L.ignore_ids.end())
+      continue;
     if (in_shadow(scene, rec.p, L))
       continue;
     Vec3 ldir = (L.position - rec.p).normalized();

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -5,6 +5,7 @@
 #include "rt/Camera.hpp"
 #include <algorithm>
 #include <limits>
+#include <unordered_map>
 
 namespace
 {
@@ -22,6 +23,7 @@ void Scene::update_beams(const std::vector<Material> &mats)
   std::vector<std::shared_ptr<Beam>> roots;
   std::vector<HittablePtr> non_beams;
   non_beams.reserve(objects.size());
+  std::unordered_map<int, int> id_map;
 
   for (auto &obj : objects)
   {
@@ -40,7 +42,10 @@ void Scene::update_beams(const std::vector<Material> &mats)
   }
 
   for (size_t i = 0; i < non_beams.size(); ++i)
+  {
+    id_map[non_beams[i]->object_id] = static_cast<int>(i);
     non_beams[i]->object_id = static_cast<int>(i);
+  }
 
   objects = std::move(non_beams);
   int next_oid = static_cast<int>(objects.size());
@@ -49,6 +54,8 @@ void Scene::update_beams(const std::vector<Material> &mats)
   for (size_t i = 0; i < to_process.size(); ++i)
   {
     auto bm = to_process[i];
+    if (i < roots.size())
+      id_map[bm->object_id] = next_oid;
     bm->object_id = next_oid;
     objects.push_back(bm);
     ++next_oid;
@@ -91,6 +98,22 @@ void Scene::update_beams(const std::vector<Material> &mats)
       }
     }
   }
+
+  for (auto &L : lights)
+  {
+    if (L.attached_id >= 0)
+    {
+      auto it = id_map.find(L.attached_id);
+      if (it != id_map.end())
+        L.attached_id = it->second;
+    }
+    for (int &ign : L.ignore_ids)
+    {
+      auto it = id_map.find(ign);
+      if (it != id_map.end())
+        ign = it->second;
+    }
+  }
 }
 
 void Scene::build_bvh()
@@ -116,10 +139,18 @@ Vec3 Scene::move_with_collision(int index, const Vec3 &delta)
   if (!obj || obj->is_beam())
     return Vec3(0, 0, 0);
 
+  auto move_lights = [&](const Vec3 &d) {
+    for (auto &L : lights)
+      if (L.attached_id == obj->object_id)
+        L.position += d;
+  };
+
   obj->translate(delta);
+  move_lights(delta);
   if (!collides(index))
     return delta;
   obj->translate(delta * -1);
+  move_lights(delta * -1);
 
   Vec3 moved(0, 0, 0);
   Vec3 axes[3] = {Vec3(delta.x, 0, 0), Vec3(0, delta.y, 0),
@@ -129,10 +160,16 @@ Vec3 Scene::move_with_collision(int index, const Vec3 &delta)
     if (ax.length_squared() == 0)
       continue;
     obj->translate(ax);
+    move_lights(ax);
     if (collides(index))
+    {
       obj->translate(ax * -1);
+      move_lights(ax * -1);
+    }
     else
+    {
       moved += ax;
+    }
   }
   return moved;
 }

--- a/src/light.cpp
+++ b/src/light.cpp
@@ -1,11 +1,13 @@
 #include "rt/light.hpp"
+#include <utility>
 
 namespace rt
 {
-PointLight::PointLight(const Vec3 &p, const Vec3 &c, double i)
-    : position(p), color(c), intensity(i)
-{
-}
+PointLight::PointLight(const Vec3 &p, const Vec3 &c, double i,
+                       std::vector<int> ignore_ids, int attached_id)
+    : position(p), color(c), intensity(i),
+      ignore_ids(std::move(ignore_ids)), attached_id(attached_id)
+{}
 
 Ambient::Ambient(const Vec3 &c, double i) : color(c), intensity(i) {}
 


### PR DESCRIPTION
## Summary
- Add `HoledSphere` geometry with a quarter-diameter opening to shape beam-source light into a spotlight
- Compose beam sources from outer shells plus movable holed inner sphere so the inner sphere physically blocks light except through the hole
- Construct inner holed sphere in parser and keep it out of light's ignore list, while continuing to ignore outer shell and beam geometry
- Modify shadow checks to evaluate ignore lists per-hit so inner sphere can occlude the internal light

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`


------
https://chatgpt.com/codex/tasks/task_e_68b5981aafcc832faf567d5d9aa607eb