### PR TITLE
Add internal light to beam sources

### DIFF
--- a/include/rt/BeamSource.hpp
+++ b/include/rt/BeamSource.hpp
@@ -16,5 +16,6 @@ struct BeamSource : public Sphere
   bool bounding_box(AABB &out) const override { return Sphere::bounding_box(out); }
   void translate(const Vec3 &delta) override;
   void rotate(const Vec3 &axis, double angle) override;
+  Vec3 spot_direction() const override;
 };
 } // namespace rt

--- a/include/rt/Hittable.hpp
+++ b/include/rt/Hittable.hpp
@@ -55,6 +55,7 @@ struct Hittable
     (void)axis;
     (void)angle;
   }
+  virtual Vec3 spot_direction() const { return Vec3(0, 0, 0); }
 };
 
 using HittablePtr = std::shared_ptr<Hittable>;

--- a/include/rt/light.hpp
+++ b/include/rt/light.hpp
@@ -1,6 +1,7 @@
 
 #pragma once
 #include "Vec3.hpp"
+#include <vector>
 
 namespace rt
 {
@@ -9,8 +10,14 @@ struct PointLight
   Vec3 position;
   Vec3 color;
   double intensity;
+  std::vector<int> ignore_ids;
+  int attached_id;
+  Vec3 direction;
+  double cutoff_cos;
 
-  PointLight(const Vec3 &p, const Vec3 &c, double i);
+  PointLight(const Vec3 &p, const Vec3 &c, double i,
+             std::vector<int> ignore_ids = {}, int attached_id = -1,
+             const Vec3 &dir = Vec3(0, 0, 0), double cutoff_cos = -1.0);
 };
 
 struct Ambient

--- a/src/BeamSource.cpp
+++ b/src/BeamSource.cpp
@@ -7,8 +7,8 @@ BeamSource::BeamSource(const Vec3 &c, const Vec3 &dir,
                        const std::shared_ptr<Beam> &bm, int oid,
                        int mat_big, int mat_mid, int mat_small)
     : Sphere(c, 0.6, oid, mat_big),
-      mid(c, 0.6 * 0.67, oid, mat_mid),
-      inner(c, 0.6 * 0.33, oid, mat_small), beam(bm)
+      mid(c, 0.6 * 0.67, -oid - 1, mat_mid),
+      inner(c, 0.6 * 0.33, -oid - 2, mat_small), beam(bm)
 {
 }
 
@@ -31,12 +31,16 @@ bool BeamSource::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) con
   }
   if (inner.hit(r, tmin, closest, tmp))
   {
-    hit_any = true;
-    closest = tmp.t;
-    rec = tmp;
+    Vec3 beam_dir = beam ? beam->path.dir : Vec3(0, 0, 1);
+    Vec3 to_hit = (tmp.p - inner.center).normalized();
+    const double hole_cos = std::sqrt(1.0 - 0.25 * 0.25);
+    if (Vec3::dot(beam_dir, to_hit) < hole_cos)
+    {
+      hit_any = true;
+      closest = tmp.t;
+      rec = tmp;
+    }
   }
-  if (hit_any)
-    rec.object_id = object_id;
   return hit_any;
 }
 
@@ -58,6 +62,11 @@ void BeamSource::rotate(const Vec3 &ax, double angle)
   };
   if (beam)
     beam->path.dir = rotate_vec(beam->path.dir, ax, angle).normalized();
+}
+
+Vec3 BeamSource::spot_direction() const
+{
+  return beam ? beam->path.dir : Vec3(0, 0, 1);
 }
 
 } // namespace rt

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -296,7 +296,8 @@ bool Parser::parse_rt_file(const std::string &path, Scene &outScene,
         materials.back().random_alpha = true;
         int beam_mat = mid++;
 
-        auto bm = std::make_shared<Beam>(o, dir, g, L, oid++, beam_mat);
+        Vec3 dir_norm = dir.normalized();
+        auto bm = std::make_shared<Beam>(o, dir_norm, g, L, oid++, beam_mat);
 
         materials.emplace_back();
         materials.back().color = Vec3(1.0, 1.0, 1.0);
@@ -316,12 +317,17 @@ bool Parser::parse_rt_file(const std::string &path, Scene &outScene,
         materials.back().alpha = 1.0;
         int small_mat = mid++;
 
-        auto src = std::make_shared<BeamSource>(o, dir, bm, oid++, big_mat,
-                                                mid_mat, small_mat);
+        auto src = std::make_shared<BeamSource>(o, dir_norm, bm, oid++,
+                                                big_mat, mid_mat, small_mat);
         src->movable = (s_move == "M");
         bm->source = src;
         outScene.objects.push_back(bm);
         outScene.objects.push_back(src);
+        const double cone_cos = std::sqrt(1.0 - 0.25 * 0.25);
+        outScene.lights.emplace_back(
+            o, unit, 0.75,
+            std::vector<int>{bm->object_id, src->object_id, src->mid.object_id},
+            src->object_id, dir_norm, cone_cos);
       }
     }
     else if (id == "co")

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -5,6 +5,7 @@
 #include "rt/Camera.hpp"
 #include <algorithm>
 #include <limits>
+#include <unordered_map>
 
 namespace
 {
@@ -22,6 +23,7 @@ void Scene::update_beams(const std::vector<Material> &mats)
   std::vector<std::shared_ptr<Beam>> roots;
   std::vector<HittablePtr> non_beams;
   non_beams.reserve(objects.size());
+  std::unordered_map<int, int> id_map;
 
   for (auto &obj : objects)
   {
@@ -40,7 +42,10 @@ void Scene::update_beams(const std::vector<Material> &mats)
   }
 
   for (size_t i = 0; i < non_beams.size(); ++i)
+  {
+    id_map[non_beams[i]->object_id] = static_cast<int>(i);
     non_beams[i]->object_id = static_cast<int>(i);
+  }
 
   objects = std::move(non_beams);
   int next_oid = static_cast<int>(objects.size());
@@ -49,6 +54,8 @@ void Scene::update_beams(const std::vector<Material> &mats)
   for (size_t i = 0; i < to_process.size(); ++i)
   {
     auto bm = to_process[i];
+    if (i < roots.size())
+      id_map[bm->object_id] = next_oid;
     bm->object_id = next_oid;
     objects.push_back(bm);
     ++next_oid;
@@ -91,6 +98,28 @@ void Scene::update_beams(const std::vector<Material> &mats)
       }
     }
   }
+
+  for (auto &L : lights)
+  {
+    if (L.attached_id >= 0)
+    {
+      auto it = id_map.find(L.attached_id);
+      if (it != id_map.end())
+        L.attached_id = it->second;
+      if (L.attached_id >= 0 && L.attached_id < static_cast<int>(objects.size()))
+      {
+        Vec3 dir = objects[L.attached_id]->spot_direction();
+        if (dir.length_squared() > 0)
+          L.direction = dir.normalized();
+      }
+    }
+    for (int &ign : L.ignore_ids)
+    {
+      auto it = id_map.find(ign);
+      if (it != id_map.end())
+        ign = it->second;
+    }
+  }
 }
 
 void Scene::build_bvh()
@@ -116,10 +145,18 @@ Vec3 Scene::move_with_collision(int index, const Vec3 &delta)
   if (!obj || obj->is_beam())
     return Vec3(0, 0, 0);
 
+  auto move_lights = [&](const Vec3 &d) {
+    for (auto &L : lights)
+      if (L.attached_id == obj->object_id)
+        L.position += d;
+  };
+
   obj->translate(delta);
+  move_lights(delta);
   if (!collides(index))
     return delta;
   obj->translate(delta * -1);
+  move_lights(delta * -1);
 
   Vec3 moved(0, 0, 0);
   Vec3 axes[3] = {Vec3(delta.x, 0, 0), Vec3(0, delta.y, 0),
@@ -129,10 +166,16 @@ Vec3 Scene::move_with_collision(int index, const Vec3 &delta)
     if (ax.length_squared() == 0)
       continue;
     obj->translate(ax);
+    move_lights(ax);
     if (collides(index))
+    {
       obj->translate(ax * -1);
+      move_lights(ax * -1);
+    }
     else
+    {
       moved += ax;
+    }
   }
   return moved;
 }

--- a/src/light.cpp
+++ b/src/light.cpp
@@ -1,11 +1,15 @@
 #include "rt/light.hpp"
+#include <utility>
 
 namespace rt
 {
-PointLight::PointLight(const Vec3 &p, const Vec3 &c, double i)
-    : position(p), color(c), intensity(i)
-{
-}
+PointLight::PointLight(const Vec3 &p, const Vec3 &c, double i,
+                       std::vector<int> ignore_ids, int attached_id,
+                       const Vec3 &dir, double cutoff)
+    : position(p), color(c), intensity(i),
+      ignore_ids(std::move(ignore_ids)), attached_id(attached_id),
+      direction(dir), cutoff_cos(cutoff)
+{}
 
 Ambient::Ambient(const Vec3 &c, double i) : color(c), intensity(i) {}
 

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -25,6 +25,12 @@ Vec3 phong(const Material &m, const Ambient &ambient,
   for (const auto &L : lights)
   {
     Vec3 ldir = (L.position - p).normalized();
+    if (L.cutoff_cos > -1.0)
+    {
+      Vec3 spot_dir = (p - L.position).normalized();
+      if (Vec3::dot(L.direction, spot_dir) < L.cutoff_cos)
+        continue;
+    }
     double diff = std::max(0.0, Vec3::dot(n, ldir));
     Vec3 h = (ldir + eye).normalized();
     double spec =


### PR DESCRIPTION
## Summary
- Add direction and cutoff to point lights so beam sources emit spotlights
- Carve a quarter-diameter aperture in the beam source's inner sphere to focus light
- Update beam lights' orientation and rendering logic to follow beam direction and respect the spotlight cone

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`


------
https://chatgpt.com/codex/tasks/task_e_68b5981aafcc832faf567d5d9aa607eb