### PR TITLE
Add reflective fading light rays

### DIFF
--- a/include/rt/BeamSource.hpp
+++ b/include/rt/BeamSource.hpp
@@ -10,8 +10,10 @@ struct BeamSource : public Sphere
   Sphere mid;
   Sphere inner;
   std::shared_ptr<Beam> beam;
+  std::shared_ptr<Beam> light;
   BeamSource(const Vec3 &c, const Vec3 &dir, const std::shared_ptr<Beam> &bm,
-             int oid, int mat_big, int mat_mid, int mat_small);
+             const std::shared_ptr<Beam> &lr, int oid, int mat_big, int mat_mid,
+             int mat_small);
   bool hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const override;
   bool bounding_box(AABB &out) const override { return Sphere::bounding_box(out); }
   void translate(const Vec3 &delta) override;

--- a/src/BeamSource.cpp
+++ b/src/BeamSource.cpp
@@ -4,13 +4,13 @@
 namespace rt
 {
 BeamSource::BeamSource(const Vec3 &c, const Vec3 &dir,
-                       const std::shared_ptr<Beam> &bm, int oid,
-                       int mat_big, int mat_mid, int mat_small)
+                       const std::shared_ptr<Beam> &bm,
+                       const std::shared_ptr<Beam> &lr, int oid, int mat_big,
+                       int mat_mid, int mat_small)
     : Sphere(c, 0.6, oid, mat_big),
       mid(c, 0.6 * 0.67, -oid - 1, mat_mid),
-      inner(c, 0.6 * 0.33, -oid - 2, mat_small), beam(bm)
-{
-}
+      inner(c, 0.6 * 0.33, -oid - 2, mat_small), beam(bm), light(lr)
+{}
 
 bool BeamSource::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
 {
@@ -51,6 +51,8 @@ void BeamSource::translate(const Vec3 &delta)
   inner.translate(delta);
   if (beam)
     beam->path.orig += delta;
+  if (light)
+    light->path.orig += delta;
 }
 
 void BeamSource::rotate(const Vec3 &ax, double angle)
@@ -62,6 +64,8 @@ void BeamSource::rotate(const Vec3 &ax, double angle)
   };
   if (beam)
     beam->path.dir = rotate_vec(beam->path.dir, ax, angle).normalized();
+  if (light)
+    light->path.dir = rotate_vec(light->path.dir, ax, angle).normalized();
 }
 
 Vec3 BeamSource::spot_direction() const

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -102,8 +102,7 @@ static Vec3 trace_ray(const Scene &scene, const std::vector<Material> &mats,
   if (m.random_alpha)
   {
     double tpos = std::clamp(rec.beam_ratio, 0.0, 1.0);
-    double rand = (1.0 - tpos) * std::pow(dist(rng), tpos);
-    alpha *= rand;
+    alpha *= (1.0 - tpos);
   }
   if (alpha < 1.0)
   {


### PR DESCRIPTION
## Summary
- render beams with a secondary light ray that's slightly larger
- allow light rays to reflect and fade out along their length
- adjust parser and source to manage dual-beam emitters

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`


------
https://chatgpt.com/codex/tasks/task_e_68b6e0db1a90832fbb1b949c1848c902