### PR TITLE
Align beam source hole with beam width

### DIFF
--- a/src/BeamSource.cpp
+++ b/src/BeamSource.cpp
@@ -1,5 +1,6 @@
 #include "rt/BeamSource.hpp"
 #include <cmath>
+#include <algorithm>
 
 namespace rt
 {
@@ -33,7 +34,10 @@ bool BeamSource::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) con
   {
     Vec3 beam_dir = beam ? beam->path.dir : Vec3(0, 0, 1);
     Vec3 to_hit = (tmp.p - inner.center).normalized();
-    const double hole_cos = std::sqrt(1.0 - 0.25 * 0.25);
+    double ratio = 0.25;
+    if (beam)
+      ratio = std::clamp(beam->radius / inner.radius, 0.0, 1.0);
+    double hole_cos = std::sqrt(1.0 - ratio * ratio);
     if (Vec3::dot(beam_dir, to_hit) < hole_cos)
     {
       hit_any = true;

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -326,7 +326,8 @@ bool Parser::parse_rt_file(const std::string &path, Scene &outScene,
         bm->source = src;
         outScene.objects.push_back(bm);
         outScene.objects.push_back(src);
-        const double cone_cos = std::sqrt(1.0 - 0.25 * 0.25);
+        double ratio = std::clamp(g / (0.6 * 0.33), 0.0, 1.0);
+        double cone_cos = std::sqrt(1.0 - ratio * ratio);
         outScene.lights.emplace_back(
             o, unit, 0.75,
             std::vector<int>{bm->object_id, src->object_id, src->mid.object_id},


### PR DESCRIPTION
## Summary
- Match beam source inner hole to the beam's actual radius
- Derive spotlight cutoff from beam radius so light and beam share width

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`
- `./build/minirt scenes/test.rt 10 10 L` *(fails: XDG_RUNTIME_DIR is invalid or not set)*

------
https://chatgpt.com/codex/tasks/task_e_68b839c68720832f870a112767e8ccfa