### PR TITLE
Match beam source hole to beam width

### DIFF
--- a/src/BeamSource.cpp
+++ b/src/BeamSource.cpp
@@ -33,7 +33,10 @@ bool BeamSource::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) con
   {
     Vec3 beam_dir = beam ? beam->path.dir : Vec3(0, 0, 1);
     Vec3 to_hit = (tmp.p - inner.center).normalized();
-    const double hole_cos = std::sqrt(1.0 - 0.25 * 0.25);
+    double ratio = beam ? (beam->radius / inner.radius) : 0.25;
+    if (ratio > 1.0)
+      ratio = 1.0;
+    const double hole_cos = std::sqrt(1.0 - ratio * ratio);
     if (Vec3::dot(beam_dir, to_hit) < hole_cos)
     {
       hit_any = true;


### PR DESCRIPTION
## Summary
- Size beam source inner hole by beam radius so emitted ray matches the beam cylinder

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`

------
https://chatgpt.com/codex/tasks/task_e_68b839c68720832f870a112767e8ccfa