### PR TITLE
Fix reflected beam light not lighting subsequent objects

### DIFF
--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -63,8 +63,11 @@ void Scene::update_beams(const std::vector<Material> &mats)
 
   for (size_t i = 0; i < non_beams.size(); ++i)
   {
-    id_map[non_beams[i]->object_id] = static_cast<int>(i);
-    non_beams[i]->object_id = static_cast<int>(i);
+    int old_id = non_beams[i]->object_id;
+    int new_id = static_cast<int>(i);
+    id_map[old_id] = new_id;
+    id_map[new_id] = new_id;
+    non_beams[i]->object_id = new_id;
   }
 
   objects = std::move(non_beams);


### PR DESCRIPTION
## Summary
- Prevent remapping of new object IDs when updating beam lights
- Ensure reflected beams correctly generate light sources for subsequent hits

## Testing
- `cmake --build .`

------
https://chatgpt.com/codex/tasks/task_e_68b85b211fc8832f8196b621ef124b2e