### PR TITLE
Align reflection lights with beam dimensions

### DIFF
--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -331,7 +331,10 @@ bool Parser::parse_rt_file(const std::string &path, Scene &outScene,
         bm->source = src;
         outScene.objects.push_back(bm);
         outScene.objects.push_back(src);
-        const double cone_cos = std::sqrt(1.0 - 0.25 * 0.25);
+        double spot_ratio = 1.0;
+        if (L > 1e-9)
+          spot_ratio = std::clamp(g / L, 0.0, 1.0);
+        double cone_cos = std::sqrt(std::max(0.0, 1.0 - spot_ratio * spot_ratio));
         outScene.lights.emplace_back(
             o, unit, intensity,
             std::vector<int>{bm->object_id, src->object_id, src->mid.object_id},

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -130,7 +130,12 @@ void Scene::update_beams(const std::vector<Material> &mats)
   {
     auto bm = pl.beam;
     Vec3 light_col = mats[bm->material_id].base_color;
-    const double cone_cos = std::sqrt(1.0 - 0.25 * 0.25);
+    double cone_cos = -1.0;
+    if (bm->length > 1e-9)
+    {
+      double spot_ratio = std::clamp(bm->radius / bm->length, 0.0, 1.0);
+      cone_cos = std::sqrt(std::max(0.0, 1.0 - spot_ratio * spot_ratio));
+    }
     double remain = bm->total_length - bm->start;
     double ratio = (bm->total_length > 0.0) ? remain / bm->total_length : 0.0;
     lights.emplace_back(bm->path.orig, light_col, bm->light_intensity * ratio,


### PR DESCRIPTION
## Summary
- Compute beam light cone from its radius and length when parsing scenes
- Preserve beam girth in reflection lights by deriving cone cutoff from actual beam size

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`


------
https://chatgpt.com/codex/tasks/task_e_68b86e225fa8832f8d95541c01afe670