### PR TITLE
Revamp beam mechanics with multi-part sources and fading lasers

### DIFF
--- a/include/rt/BeamSource.hpp
+++ b/include/rt/BeamSource.hpp
@@ -10,7 +10,7 @@ struct BeamSource : public Sphere
   Sphere mid;
   Sphere inner;
   std::shared_ptr<Beam> beam;
-  BeamSource(const Vec3 &c, const Vec3 &dir, const std::shared_ptr<Beam> &bm,
+  BeamSource(const Vec3 &c, double radius, const std::shared_ptr<Beam> &bm,
              int oid, int mat_big, int mat_mid, int mat_small);
   bool hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const override;
   bool bounding_box(AABB &out) const override { return Sphere::bounding_box(out); }

--- a/include/rt/material.hpp
+++ b/include/rt/material.hpp
@@ -16,8 +16,11 @@ struct Material
   double specular_exp = 50.0;
   double specular_k = 0.5;
   bool mirror = false;
-  bool random_alpha = false;
-  bool checkered = false; // render as checkered pattern when true
+  bool beam_falloff = false;  // fade alpha along beam length
+  bool checkered = false;     // render as checkered pattern when true
+  bool unlit = false;         // render without lighting when true
+  bool casts_shadow = true;   // participate in shadow tests
+  bool solid = true;          // blocks movement and collisions
 };
 
 Vec3 phong(const Material &m, const Ambient &ambient,

--- a/src/BeamSource.cpp
+++ b/src/BeamSource.cpp
@@ -3,12 +3,12 @@
 
 namespace rt
 {
-BeamSource::BeamSource(const Vec3 &c, const Vec3 &dir,
+BeamSource::BeamSource(const Vec3 &c, double radius,
                        const std::shared_ptr<Beam> &bm, int oid,
                        int mat_big, int mat_mid, int mat_small)
-    : Sphere(c, 0.6, oid, mat_big),
-      mid(c, 0.6 * 0.67, -oid - 1, mat_mid),
-      inner(c, 0.6 * 0.33, -oid - 2, mat_small), beam(bm)
+    : Sphere(c, radius * 1.33 * 1.33, oid, mat_big),
+      mid(c, radius * 1.33, -oid - 1, mat_mid),
+      inner(c, radius, -oid - 2, mat_small), beam(bm)
 {
 }
 
@@ -31,15 +31,9 @@ bool BeamSource::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) con
   }
   if (inner.hit(r, tmin, closest, tmp))
   {
-    Vec3 beam_dir = beam ? beam->path.dir : Vec3(0, 0, 1);
-    Vec3 to_hit = (tmp.p - inner.center).normalized();
-    const double hole_cos = std::sqrt(1.0 - 0.25 * 0.25);
-    if (Vec3::dot(beam_dir, to_hit) < hole_cos)
-    {
-      hit_any = true;
-      closest = tmp.t;
-      rec = tmp;
-    }
+    hit_any = true;
+    closest = tmp.t;
+    rec = tmp;
   }
   return hit_any;
 }


### PR DESCRIPTION
## Summary
- Implement multi-sphere beam sources with graded colors and transparencies
- Add deterministic alpha falloff for beam lasers and unlit rendering for visual elements
- Introduce solid/shadow flags and rebuild beam updates with proper light reflections

## Testing
- ✅ `cmake -S . -B build`
- ✅ `cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_68b9685ed800832fbd4bda078527836e