### PR TITLE
Fix reflected beam light intensity

### DIFF
--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -134,11 +134,8 @@ void Scene::process_beams(const std::vector<Material> &mats,
                 auto bm = pl.beam;
                 Vec3 light_col = mats[bm->material_id].base_color;
                 const double cone_cos = std::sqrt(1.0 - 0.25 * 0.25);
-                double remain = bm->total_length - bm->start;
-                double ratio =
-                        (bm->total_length > 0.0) ? remain / bm->total_length : 0.0;
                 lights.emplace_back(bm->path.orig, light_col,
-                                                        bm->light_intensity * ratio,
+                                                        bm->light_intensity,
                                                         std::vector<int>{bm->object_id, pl.hit_id},
                                                         bm->object_id, bm->path.dir, cone_cos, bm->length);
         }


### PR DESCRIPTION
## Summary
- Ensure reflected beams generate point lights using the full beam intensity

## Testing
- `cmake -S . -B build` (fails: Could not find SDL2Config.cmake)


------
https://chatgpt.com/codex/tasks/task_e_68bdbebc4b80832fa18d3ecd0f7cc239