### PR TITLE
feat: add invisible camera collision sphere

### DIFF
--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -3,6 +3,7 @@
 #include "Collision.hpp"
 #include "Laser.hpp"
 #include "Plane.hpp"
+#include "Sphere.hpp"
 #include <algorithm>
 #include <cmath>
 #include <limits>
@@ -278,52 +279,49 @@ void Scene::attempt_axis_move(int index, const Vec3 &axis_delta, Vec3 &moved)
 	}
 }
 
-// Move camera with collision avoidance.
+// Move camera with collision avoidance using a small collision sphere.
 Vec3 Scene::move_camera(Camera &cam, const Vec3 &delta,
-						const std::vector<Material> &mats) const
+                                                const std::vector<Material> &mats) const
 {
-	auto blocked = [&](const Vec3 &start, const Vec3 &d)
-	{
-		double len = d.length();
-		if (len <= 0.0)
-			return false;
-		Ray r(start, d / len);
-		HitRecord tmp;
-		for (const auto &obj : objects)
-		{
-			if (obj->is_beam())
-				continue;
-			const Material &mat = mats[obj->material_id];
-			if (mat.alpha < 1.0)
-				continue;
-			if (obj->hit(r, 1e-4, len, tmp))
-				return true;
-		}
-		return false;
-	};
+        // Transparent shield sphere around camera
+        auto shield = std::make_shared<Sphere>(cam.origin, 0.2, -1, 0);
 
-	Vec3 start = cam.origin;
-	if (!blocked(start, delta))
-	{
-		cam.move(delta);
-		return delta;
-	}
+        auto collides_at = [&](const Vec3 &pos) {
+                shield->center = pos;
+                for (const auto &obj : objects)
+                {
+                        if (obj->is_beam())
+                                continue;
+                        const Material &mat = mats[obj->material_id];
+                        if (mat.alpha < 1.0)
+                                continue;
+                        if (precise_collision(shield, obj))
+                                return true;
+                }
+                return false;
+        };
 
-	Vec3 moved(0, 0, 0);
-	Vec3 axes[3] = {Vec3(delta.x, 0, 0), Vec3(0, delta.y, 0),
-					Vec3(0, 0, delta.z)};
-	for (const Vec3 &ax : axes)
-	{
-		if (ax.length_squared() == 0)
-			continue;
-		if (!blocked(start, ax))
-		{
-			cam.move(ax);
-			start += ax;
-			moved += ax;
-		}
-	}
-	return moved;
+        Vec3 start = cam.origin;
+        if (!collides_at(start + delta))
+        {
+                cam.move(delta);
+                return delta;
+        }
+
+        Vec3 moved(0, 0, 0);
+        Vec3 axes[3] = {Vec3(delta.x, 0, 0), Vec3(0, delta.y, 0),
+                                        Vec3(0, 0, delta.z)};
+        for (const Vec3 &ax : axes)
+        {
+                if (ax.length_squared() == 0)
+                        continue;
+                if (!collides_at(start + moved + ax))
+                {
+                        cam.move(ax);
+                        moved += ax;
+                }
+        }
+        return moved;
 }
 
 // Check if object at index intersects any other object.


### PR DESCRIPTION
## Summary
- wrap camera in a non-interactive transparent sphere to stop it entering solid objects

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`


------
https://chatgpt.com/codex/tasks/task_e_68c03a48ad44832f88c83e667a27e92c