### PR TITLE
Add colorful main menu and placeholders for future screens

### DIFF
--- a/inc/Leaderboard.hpp
+++ b/inc/Leaderboard.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+/**
+ * Placeholder for future leaderboard implementation.
+ */
+class Leaderboard
+{
+public:
+        static void show();
+};
+

--- a/inc/Settings.hpp
+++ b/inc/Settings.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+/**
+ * Placeholder for future settings implementation.
+ */
+class Settings
+{
+public:
+        static void show();
+};
+

--- a/src/Leaderboard.cpp
+++ b/src/Leaderboard.cpp
@@ -1,0 +1,7 @@
+#include "Leaderboard.hpp"
+
+void Leaderboard::show()
+{
+        // To be implemented
+}
+

--- a/src/MainMenu.cpp
+++ b/src/MainMenu.cpp
@@ -8,42 +8,72 @@ const uint8_t *get_glyph(char character)
 {
 	switch (character)
 	{
-	case 'A':
+        case 'A':
 	{
 		static const uint8_t data[7] = {0x0E, 0x11, 0x11, 0x1F,
 										0x11, 0x11, 0x11};
 		return data;
 	}
-	case 'E':
+        case 'B':
+        {
+                static const uint8_t data[7] = {0x1E, 0x11, 0x11, 0x1E,
+                                                                                0x11, 0x11, 0x1E};
+                return data;
+        }
+        case 'D':
+        {
+                static const uint8_t data[7] = {0x1E, 0x11, 0x11, 0x11,
+                                                                                0x11, 0x11, 0x1E};
+                return data;
+        }
+        case 'E':
 	{
 		static const uint8_t data[7] = {0x1F, 0x10, 0x10, 0x1E,
 										0x10, 0x10, 0x1F};
 		return data;
 	}
-	case 'G':
+        case 'G':
 	{
 		static const uint8_t data[7] = {0x0F, 0x10, 0x10, 0x13,
 										0x11, 0x11, 0x0F};
 		return data;
 	}
-	case 'I':
+        case 'H':
+        {
+                static const uint8_t data[7] = {0x11, 0x11, 0x11, 0x1F,
+                                                                                0x11, 0x11, 0x11};
+                return data;
+        }
+        case 'I':
 	{
 		static const uint8_t data[7] = {0x1F, 0x04, 0x04, 0x04,
 										0x04, 0x04, 0x1F};
 		return data;
 	}
-	case 'L':
+        case 'L':
 	{
 		static const uint8_t data[7] = {0x10, 0x10, 0x10, 0x10,
 										0x10, 0x10, 0x1F};
 		return data;
 	}
-	case 'N':
+        case 'M':
+        {
+                static const uint8_t data[7] = {0x11, 0x1B, 0x15, 0x11,
+                                                                                0x11, 0x11, 0x11};
+                return data;
+        }
+        case 'N':
 	{
 		static const uint8_t data[7] = {0x11, 0x19, 0x15, 0x13,
 										0x11, 0x11, 0x11};
 		return data;
 	}
+        case 'O':
+        {
+                static const uint8_t data[7] = {0x0E, 0x11, 0x11, 0x11,
+                                                                                0x11, 0x11, 0x0E};
+                return data;
+        }
         case 'P':
         {
                 static const uint8_t data[7] = {0x1E, 0x11, 0x11, 0x1E,
@@ -54,6 +84,12 @@ const uint8_t *get_glyph(char character)
         {
                 static const uint8_t data[7] = {0x0E, 0x11, 0x11, 0x11,
                                                                                 0x11, 0x13, 0x0F};
+                return data;
+        }
+        case 'R':
+        {
+                static const uint8_t data[7] = {0x1E, 0x11, 0x11, 0x1E,
+                                                                                0x14, 0x12, 0x11};
                 return data;
         }
         case 'S':
@@ -151,23 +187,47 @@ bool MainMenu::show(int width, int height)
         button_width = 300;
         int button_height;
         button_height = 100;
-        int margin;
-        margin = (height - 3 * button_height) / 4;
+        int scale;
+        scale = 4;
+        int title_scale;
+        title_scale = scale * 2;
+        std::string title;
+        title = "MINIRT THE GAME";
+        int button_gap;
+        button_gap = 10;
+        int title_gap;
+        title_gap = 30;
+        int total_buttons_height;
+        total_buttons_height = 4 * button_height + 3 * button_gap;
+        int title_height;
+        title_height = 7 * title_scale;
+        int top_margin;
+        top_margin = (height - title_height - title_gap - total_buttons_height) / 2;
+        if (top_margin < 0)
+                top_margin = 0;
+        int title_x;
+        title_x = width / 2 - text_width(title, title_scale) / 2;
+        int title_y;
+        title_y = top_margin;
+        int play_y;
+        play_y = title_y + title_height + title_gap;
+        int center_x;
+        center_x = width / 2 - button_width / 2;
         SDL_Rect play_rect;
-        play_rect = {width / 2 - button_width / 2, margin, button_width,
-                                  button_height};
+        play_rect = {center_x, play_y, button_width, button_height};
+        SDL_Rect leaderboard_rect;
+        leaderboard_rect = {center_x, play_rect.y + button_height + button_gap,
+                                                button_width, button_height};
         SDL_Rect settings_rect;
-        settings_rect = {width / 2 - button_width / 2,
-                                         margin * 2 + button_height, button_width,
-                                         button_height};
+        settings_rect = {center_x, leaderboard_rect.y + button_height +
+                                         button_gap, button_width, button_height};
         SDL_Rect quit_rect;
-        quit_rect = {width / 2 - button_width / 2,
-                                      margin * 3 + 2 * button_height, button_width,
-                                      button_height};
+        quit_rect = {center_x, settings_rect.y + button_height + button_gap,
+                                      button_width, button_height};
         bool running;
         running = true;
-	bool play_selected;
-	play_selected = false;
+        bool play_selected;
+        play_selected = false;
 	while (running)
 	{
 		SDL_Event event;
@@ -203,11 +263,19 @@ bool MainMenu::show(int width, int height)
                 }
                 int mouse_x;
                 int mouse_y;
-		SDL_GetMouseState(&mouse_x, &mouse_y);
-		bool hover_play;
-		hover_play =
-			mouse_x >= play_rect.x && mouse_x < play_rect.x + play_rect.w &&
-			mouse_y >= play_rect.y && mouse_y < play_rect.y + play_rect.h;
+                SDL_GetMouseState(&mouse_x, &mouse_y);
+                bool hover_play;
+                hover_play = mouse_x >= play_rect.x &&
+                                         mouse_x < play_rect.x + play_rect.w &&
+                                         mouse_y >= play_rect.y &&
+                                         mouse_y < play_rect.y + play_rect.h;
+                bool hover_leaderboard;
+                hover_leaderboard = mouse_x >= leaderboard_rect.x &&
+                                                     mouse_x < leaderboard_rect.x +
+                                                                          leaderboard_rect.w &&
+                                                     mouse_y >= leaderboard_rect.y &&
+                                                     mouse_y < leaderboard_rect.y +
+                                                                          leaderboard_rect.h;
                 bool hover_settings;
                 hover_settings = mouse_x >= settings_rect.x &&
                                                  mouse_x < settings_rect.x + settings_rect.w &&
@@ -220,35 +288,71 @@ bool MainMenu::show(int width, int height)
                                          mouse_y < quit_rect.y + quit_rect.h;
                 SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
                 SDL_RenderClear(renderer);
+                SDL_Color white;
+                white = {255, 255, 255, 255};
+                int x;
+                x = title_x;
+                for (std::size_t i = 0; i < title.size(); ++i)
+                {
+                        SDL_Color color;
+                        color = white;
+                        if (i == 0)
+                                color = {0, 0, 255, 255};
+                        else if (i == 1)
+                                color = {255, 255, 0, 255};
+                        else if (i == 2)
+                                color = {0, 255, 0, 255};
+                        else if (i == 3)
+                                color = {255, 0, 0, 255};
+                        else if (i == 4)
+                                color = {0, 255, 255, 255};
+                        else if (i == 5)
+                                color = {128, 0, 128, 255};
+                        draw_character(renderer, title[i], x, title_y, color,
+                                                        title_scale);
+                        x += (5 + 1) * title_scale;
+                }
                 SDL_Color fill;
-                fill =
-                        hover_play ? SDL_Color{0, 128, 128, 255} : SDL_Color{0, 0, 0, 255};
-		SDL_SetRenderDrawColor(renderer, fill.r, fill.g, fill.b, fill.a);
-		SDL_RenderFillRect(renderer, &play_rect);
-		SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
-		SDL_RenderDrawRect(renderer, &play_rect);
-		int scale;
-		scale = 4;
-		SDL_Color white;
-		white = {255, 255, 255, 255};
-		int text_x;
-		int text_y;
-		text_x = play_rect.x + (play_rect.w - text_width("PLAY", scale)) / 2;
-		text_y = play_rect.y + (play_rect.h - 7 * scale) / 2;
-		draw_text(renderer, "PLAY", text_x, text_y, white, scale);
-		fill = hover_settings ? SDL_Color{0, 128, 128, 255}
-							  : SDL_Color{0, 0, 0, 255};
-		SDL_SetRenderDrawColor(renderer, fill.r, fill.g, fill.b, fill.a);
-		SDL_RenderFillRect(renderer, &settings_rect);
-		SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
+                fill = hover_play ? SDL_Color{0, 255, 0, 255}
+                                                  : SDL_Color{0, 0, 0, 255};
+                SDL_SetRenderDrawColor(renderer, fill.r, fill.g, fill.b, fill.a);
+                SDL_RenderFillRect(renderer, &play_rect);
+                SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
+                SDL_RenderDrawRect(renderer, &play_rect);
+                int text_x;
+                int text_y;
+                text_x = play_rect.x + (play_rect.w - text_width("PLAY", scale)) / 2;
+                text_y = play_rect.y + (play_rect.h - 7 * scale) / 2;
+                draw_text(renderer, "PLAY", text_x, text_y, white, scale);
+                SDL_Color fill_leader;
+                fill_leader = hover_leaderboard ? SDL_Color{0, 0, 255, 255}
+                                                                : SDL_Color{0, 0, 0, 255};
+                SDL_SetRenderDrawColor(renderer, fill_leader.r, fill_leader.g,
+                                                       fill_leader.b, fill_leader.a);
+                SDL_RenderFillRect(renderer, &leaderboard_rect);
+                SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
+                SDL_RenderDrawRect(renderer, &leaderboard_rect);
+                text_x = leaderboard_rect.x +
+                                 (leaderboard_rect.w - text_width("LEADERBOARD", scale)) / 2;
+                text_y = leaderboard_rect.y + (leaderboard_rect.h - 7 * scale) / 2;
+                draw_text(renderer, "LEADERBOARD", text_x, text_y, white, scale);
+                SDL_Color fill_settings;
+                fill_settings = hover_settings ? SDL_Color{255, 255, 0, 255}
+                                                                : SDL_Color{0, 0, 0, 255};
+                SDL_SetRenderDrawColor(renderer, fill_settings.r, fill_settings.g,
+                                                       fill_settings.b, fill_settings.a);
+                SDL_RenderFillRect(renderer, &settings_rect);
+                SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
                 SDL_RenderDrawRect(renderer, &settings_rect);
                 text_x = settings_rect.x +
                                  (settings_rect.w - text_width("SETTINGS", scale)) / 2;
                 text_y = settings_rect.y + (settings_rect.h - 7 * scale) / 2;
                 draw_text(renderer, "SETTINGS", text_x, text_y, white, scale);
-                fill = hover_quit ? SDL_Color{0, 128, 128, 255}
-                                                  : SDL_Color{0, 0, 0, 255};
-                SDL_SetRenderDrawColor(renderer, fill.r, fill.g, fill.b, fill.a);
+                SDL_Color fill_quit;
+                fill_quit = hover_quit ? SDL_Color{255, 0, 0, 255}
+                                                    : SDL_Color{0, 0, 0, 255};
+                SDL_SetRenderDrawColor(renderer, fill_quit.r, fill_quit.g, fill_quit.b,
+                                                       fill_quit.a);
                 SDL_RenderFillRect(renderer, &quit_rect);
                 SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
                 SDL_RenderDrawRect(renderer, &quit_rect);

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -1,0 +1,7 @@
+#include "Settings.hpp"
+
+void Settings::show()
+{
+        // To be implemented
+}
+


### PR DESCRIPTION
## Summary
- Draw "MINIRT THE GAME" title with per-letter colors
- Introduce distinct hover colors for Play, Leaderboard, Settings and Quit buttons
- Stub out placeholder classes for future Leaderboard and Settings screens
- Enlarge the title and tighten spacing so Play and Quit buttons mirror top and bottom edges
- Increase spacing above buttons and balance title so top and bottom margins match

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68c12e426ae4832fa02b84df5c15892c