### PR TITLE
Add configurable settings menu with sliders and YAML persistence

### DIFF
--- a/inc/Button.hpp
+++ b/inc/Button.hpp
@@ -10,6 +10,7 @@ enum class ButtonAction {
     Settings,
     Leaderboard,
     Back,
+    Apply,
     Quit
 };
 

--- a/inc/ButtonsCluster.hpp
+++ b/inc/ButtonsCluster.hpp
@@ -1,0 +1,15 @@
+#pragma once
+#include "Button.hpp"
+#include <vector>
+
+class ButtonsCluster {
+    std::vector<Button> buttons;
+    int selected;
+public:
+    ButtonsCluster(const std::vector<std::string> &names, int initial = 0);
+    void set_rect(int x, int y, int w, int h, int gap);
+    void handle_event(const SDL_Event &e);
+    void render(SDL_Renderer *renderer, int scale) const;
+    int current_index() const { return selected; }
+    const std::string &current_text() const { return buttons[selected].text; }
+};

--- a/inc/Settings.hpp
+++ b/inc/Settings.hpp
@@ -1,0 +1,13 @@
+#pragma once
+#include <string>
+
+struct Settings {
+    int width = 1080;
+    int height = 720;
+    char quality = 'H';
+    double mouse_sensitivity = 1.0; // multiplier
+};
+
+Settings &get_settings();
+bool load_settings(const std::string &path);
+bool save_settings(const std::string &path);

--- a/inc/SettingsMenu.hpp
+++ b/inc/SettingsMenu.hpp
@@ -8,5 +8,6 @@ struct SDL_Renderer;
 class SettingsMenu : public AMenu {
 public:
     SettingsMenu();
+    ButtonAction run(SDL_Window *window, SDL_Renderer *renderer, int width, int height);
     static void show(SDL_Window *window, SDL_Renderer *renderer, int width, int height);
 };

--- a/inc/Slider.hpp
+++ b/inc/Slider.hpp
@@ -1,0 +1,19 @@
+#pragma once
+#include <SDL.h>
+#include <string>
+#include <vector>
+
+class Slider {
+    std::string label;
+    std::vector<std::string> values;
+    int index;
+    SDL_Rect bar;
+    bool dragging;
+public:
+    Slider(const std::string &label, const std::vector<std::string> &vals, int start = 0);
+    void set_rect(int x, int y, int w, int h);
+    void handle_event(const SDL_Event &e);
+    void render(SDL_Renderer *renderer, int scale) const;
+    const std::string &current() const { return values[index]; }
+    int current_index() const { return index; }
+};

--- a/src/AMenu.cpp
+++ b/src/AMenu.cpp
@@ -49,11 +49,8 @@ ButtonAction AMenu::run(SDL_Window *window, SDL_Renderer *renderer, int width, i
                 for (auto &btn : buttons) {
                     if (mx >= btn.rect.x && mx < btn.rect.x + btn.rect.w &&
                         my >= btn.rect.y && my < btn.rect.y + btn.rect.h) {
-                        if (btn.action != ButtonAction::Settings &&
-                            btn.action != ButtonAction::Leaderboard) {
-                            result = btn.action;
-                            running = false;
-                        }
+                        result = btn.action;
+                        running = false;
                         break;
                     }
                 }

--- a/src/ButtonsCluster.cpp
+++ b/src/ButtonsCluster.cpp
@@ -1,0 +1,45 @@
+#include "ButtonsCluster.hpp"
+#include "CustomCharacter.hpp"
+
+ButtonsCluster::ButtonsCluster(const std::vector<std::string> &names, int initial)
+    : selected(initial) {
+    for (const auto &n : names)
+        buttons.emplace_back(n, ButtonAction::None, SDL_Color{255,255,255,255});
+    if (selected < 0 || selected >= (int)buttons.size())
+        selected = 0;
+}
+
+void ButtonsCluster::set_rect(int x, int y, int w, int h, int gap) {
+    for (size_t i=0;i<buttons.size();++i) {
+        buttons[i].rect = {x + int(i)*(w+gap), y, w, h};
+    }
+}
+
+void ButtonsCluster::handle_event(const SDL_Event &e) {
+    if (e.type == SDL_MOUSEBUTTONDOWN && e.button.button == SDL_BUTTON_LEFT) {
+        int mx=e.button.x, my=e.button.y;
+        for (size_t i=0;i<buttons.size();++i) {
+            const SDL_Rect &r = buttons[i].rect;
+            if (mx>=r.x && mx<r.x+r.w && my>=r.y && my<r.y+r.h) {
+                selected = i;
+                break;
+            }
+        }
+    }
+}
+
+void ButtonsCluster::render(SDL_Renderer *renderer, int scale) const {
+    for (size_t i=0;i<buttons.size();++i) {
+        const SDL_Rect &r = buttons[i].rect;
+        bool sel = (int)i==selected;
+        SDL_Color fill = sel ? SDL_Color{255,255,255,255} : SDL_Color{0,0,0,255};
+        SDL_SetRenderDrawColor(renderer, fill.r, fill.g, fill.b, fill.a);
+        SDL_RenderFillRect(renderer, &r);
+        SDL_SetRenderDrawColor(renderer, 255,255,255,255);
+        SDL_RenderDrawRect(renderer, &r);
+        SDL_Color text_col = sel ? SDL_Color{0,0,0,255} : SDL_Color{255,255,255,255};
+        int text_x = r.x + (r.w - CustomCharacter::text_width(buttons[i].text, scale))/2;
+        int text_y = r.y + (r.h - 7*scale)/2;
+        CustomCharacter::draw_text(renderer, buttons[i].text, text_x, text_y, text_col, scale);
+    }
+}

--- a/src/MainMenu.cpp
+++ b/src/MainMenu.cpp
@@ -1,4 +1,6 @@
 #include "MainMenu.hpp"
+#include "SettingsMenu.hpp"
+#include "LeaderboardMenu.hpp"
 #include <SDL.h>
 
 MainMenu::MainMenu() : AMenu("MINIRT THE GAME") {
@@ -25,9 +27,24 @@ bool MainMenu::show(int width, int height) {
         return false;
     }
     MainMenu menu;
-    ButtonAction action = menu.run(window, renderer, width, height);
+    bool play = false;
+    bool open = true;
+    while (open) {
+        ButtonAction action = menu.run(window, renderer, width, height);
+        if (action == ButtonAction::Play) {
+            play = true;
+            open = false;
+        } else if (action == ButtonAction::Quit) {
+            open = false;
+        } else if (action == ButtonAction::Settings) {
+            SettingsMenu::show(window, renderer, width, height);
+            SDL_GetWindowSize(window, &width, &height);
+        } else if (action == ButtonAction::Leaderboard) {
+            LeaderboardMenu::show(window, renderer, width, height);
+        }
+    }
     SDL_DestroyRenderer(renderer);
     SDL_DestroyWindow(window);
     SDL_Quit();
-    return action == ButtonAction::Play;
+    return play;
 }

--- a/src/PauseMenu.cpp
+++ b/src/PauseMenu.cpp
@@ -1,4 +1,6 @@
 #include "PauseMenu.hpp"
+#include "SettingsMenu.hpp"
+#include "LeaderboardMenu.hpp"
 
 PauseMenu::PauseMenu() : AMenu("PAUSE") {
     title_colors.assign(title.size(), SDL_Color{255, 255, 255, 255});
@@ -10,6 +12,24 @@ PauseMenu::PauseMenu() : AMenu("PAUSE") {
 
 bool PauseMenu::show(SDL_Window *window, SDL_Renderer *renderer, int width, int height) {
     PauseMenu menu;
-    ButtonAction action = menu.run(window, renderer, width, height);
-    return action == ButtonAction::Resume;
+    bool resume = false;
+    bool open = true;
+    while (open) {
+        ButtonAction action = menu.run(window, renderer, width, height);
+        if (action == ButtonAction::Resume) {
+            resume = true;
+            open = false;
+        } else if (action == ButtonAction::Quit) {
+            resume = false;
+            open = false;
+        } else if (action == ButtonAction::Settings) {
+            SettingsMenu::show(window, renderer, width, height);
+            SDL_GetWindowSize(window, &width, &height);
+        } else if (action == ButtonAction::Leaderboard) {
+            LeaderboardMenu::show(window, renderer, width, height);
+        } else if (action == ButtonAction::Back) {
+            open = false;
+        }
+    }
+    return resume;
 }

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -1,4 +1,5 @@
 #include "Renderer.hpp"
+#include "Settings.hpp"
 #include "AABB.hpp"
 #include "Config.hpp"
 #include "Parser.hpp"
@@ -308,7 +309,7 @@ void Renderer::process_events(RenderState &st, SDL_Window *win, SDL_Renderer *re
                 {
                         if (st.edit_mode && st.rotating)
                         {
-                                double sens = MOUSE_SENSITIVITY;
+                                double sens = MOUSE_SENSITIVITY * get_settings().mouse_sensitivity;
                                 bool changed = false;
                                 double yaw = -e.motion.xrel * sens;
                                 if (yaw != 0.0)
@@ -339,7 +340,7 @@ void Renderer::process_events(RenderState &st, SDL_Window *win, SDL_Renderer *re
                         }
                         else
                         {
-                                double sens = MOUSE_SENSITIVITY;
+                                double sens = MOUSE_SENSITIVITY * get_settings().mouse_sensitivity;
                                 cam.rotate(-e.motion.xrel * sens,
                                                    -e.motion.yrel * sens);
                         }

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -1,0 +1,54 @@
+#include "Settings.hpp"
+#include <fstream>
+#include <sstream>
+#include <algorithm>
+
+static Settings g_settings; // initialized with defaults
+
+Settings &get_settings() { return g_settings; }
+
+static std::string trim(const std::string &s) {
+    size_t start = s.find_first_not_of(" \t\n\r");
+    if (start == std::string::npos) return "";
+    size_t end = s.find_last_not_of(" \t\n\r");
+    return s.substr(start, end - start + 1);
+}
+
+bool load_settings(const std::string &path) {
+    std::ifstream in(path);
+    if (!in) return false;
+    std::string line;
+    while (std::getline(in, line)) {
+        std::istringstream iss(line);
+        std::string key;
+        if (std::getline(iss, key, ':')) {
+            std::string value;
+            if (std::getline(iss, value)) {
+                key = trim(key);
+                value = trim(value);
+                if (key == "quality" && !value.empty()) {
+                    char q = value[0];
+                    if (q=='L'||q=='M'||q=='H'||q=='l'||q=='m'||q=='h')
+                        g_settings.quality = toupper(q);
+                } else if (key == "mouse_sensitivity") {
+                    g_settings.mouse_sensitivity = std::stod(value);
+                } else if (key == "width") {
+                    g_settings.width = std::stoi(value);
+                } else if (key == "height") {
+                    g_settings.height = std::stoi(value);
+                }
+            }
+        }
+    }
+    return true;
+}
+
+bool save_settings(const std::string &path) {
+    std::ofstream out(path);
+    if (!out) return false;
+    out << "quality: " << g_settings.quality << "\n";
+    out << "mouse_sensitivity: " << g_settings.mouse_sensitivity << "\n";
+    out << "width: " << g_settings.width << "\n";
+    out << "height: " << g_settings.height << "\n";
+    return true;
+}

--- a/src/SettingsMenu.cpp
+++ b/src/SettingsMenu.cpp
@@ -1,7 +1,112 @@
 #include "SettingsMenu.hpp"
+#include "ButtonsCluster.hpp"
+#include "Slider.hpp"
+#include "Settings.hpp"
+#include "CustomCharacter.hpp"
+#include <SDL.h>
+#include <sstream>
 
 SettingsMenu::SettingsMenu() : AMenu("SETTINGS") {
-    buttons.push_back(Button{"BACK", ButtonAction::Back, SDL_Color{255, 0, 0, 255}});
+    buttons.push_back(Button{"BACK", ButtonAction::Back, SDL_Color{255,0,0,255}});
+    buttons.push_back(Button{"APPLY", ButtonAction::Apply, SDL_Color{0,255,0,255}});
+}
+
+ButtonAction SettingsMenu::run(SDL_Window *window, SDL_Renderer *renderer, int width, int height) {
+    Settings &cfg = get_settings();
+    int qidx = 2;
+    if (cfg.quality == 'L') qidx = 0;
+    else if (cfg.quality == 'M') qidx = 1;
+    ButtonsCluster quality({"LOW","MEDIUM","HIGH"}, qidx);
+
+    std::vector<std::string> sensVals;
+    for (int i=1;i<=20;i++) {
+        double v = i*0.1;
+        std::ostringstream ss; ss.setf(std::ios::fixed); ss.precision(1); ss<<v; sensVals.push_back(ss.str());
+    }
+    int sensIndex = static_cast<int>((cfg.mouse_sensitivity-0.1)/0.1);
+    if (sensIndex<0) sensIndex=0; if (sensIndex>=(int)sensVals.size()) sensIndex=sensVals.size()-1;
+    Slider sensSlider("MOUSE SENSITIVITY", sensVals, sensIndex);
+
+    std::vector<std::string> resVals = {"720x480","1080x720","1366x768","1920x1080"};
+    std::string curRes = std::to_string(cfg.width)+"x"+std::to_string(cfg.height);
+    int resIndex = 1;
+    for (size_t i=0;i<resVals.size();++i) if (resVals[i]==curRes) resIndex=i;
+    Slider resSlider("RESOLUTION", resVals, resIndex);
+
+    bool running=true;
+    ButtonAction result = ButtonAction::Back;
+    while (running) {
+        SDL_GetWindowSize(window,&width,&height);
+        float scale_factor = static_cast<float>(height)/600.0f;
+        int button_width = static_cast<int>(120*scale_factor);
+        int button_height = static_cast<int>(50*scale_factor);
+        int button_gap = static_cast<int>(20*scale_factor);
+        int scale = std::max(1, static_cast<int>(4*scale_factor));
+        int title_scale = scale*2;
+
+        int bottom_y = height - button_height - 20*scale;
+        buttons[0].rect = {width/2 - button_width - button_gap/2, bottom_y, button_width, button_height};
+        buttons[1].rect = {width/2 + button_gap/2, bottom_y, button_width, button_height};
+
+        int content_y = 60*scale + 7*title_scale;
+        quality.set_rect(width/2 - (3*button_width + 2*button_gap)/2, content_y + 20*scale, button_width, button_height, button_gap);
+        int next_y = content_y + button_height + 60*scale;
+        sensSlider.set_rect(width/2 - 150*scale, next_y, 300*scale, 2*scale);
+        next_y += 60*scale;
+        resSlider.set_rect(width/2 - 150*scale, next_y, 300*scale, 2*scale);
+
+        SDL_Event e;
+        while (SDL_PollEvent(&e)) {
+            if (e.type==SDL_QUIT) { running=false; result=ButtonAction::Quit; }
+            quality.handle_event(e);
+            sensSlider.handle_event(e);
+            resSlider.handle_event(e);
+            if (e.type==SDL_MOUSEBUTTONDOWN && e.button.button==SDL_BUTTON_LEFT) {
+                int mx=e.button.x,my=e.button.y;
+                for (auto &btn:buttons) {
+                    if (mx>=btn.rect.x && mx<btn.rect.x+btn.rect.w && my>=btn.rect.y && my<btn.rect.y+btn.rect.h) {
+                        if (btn.action==ButtonAction::Back) {
+                            running=false; result=ButtonAction::Back;
+                        } else if (btn.action==ButtonAction::Apply) {
+                            int qi = quality.current_index();
+                            cfg.quality = (qi==0?'L':qi==1?'M':'H');
+                            cfg.mouse_sensitivity = std::stod(sensSlider.current());
+                            std::string r = resSlider.current();
+                            int w,h; char x; std::stringstream ss(r); ss>>w>>x>>h;
+                            cfg.width=w; cfg.height=h;
+                            save_settings("settings.yaml");
+                            SDL_SetWindowSize(window,cfg.width,cfg.height);
+                            running=false; result=ButtonAction::Apply;
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+
+        SDL_SetRenderDrawColor(renderer,0,0,0,255);
+        SDL_RenderClear(renderer);
+        SDL_Color white{255,255,255,255};
+        int title_x = width/2 - CustomCharacter::text_width(title, title_scale)/2;
+        CustomCharacter::draw_text(renderer,title,title_x,20*scale,white,title_scale);
+        int qlabel_x = width/2 - CustomCharacter::text_width("QUALITY", scale)/2;
+        CustomCharacter::draw_text(renderer,"QUALITY",qlabel_x,content_y,white,scale);
+        quality.render(renderer, scale);
+        sensSlider.render(renderer, scale);
+        resSlider.render(renderer, scale);
+        for (auto &btn : buttons) {
+            SDL_SetRenderDrawColor(renderer,0,0,0,255);
+            SDL_RenderFillRect(renderer,&btn.rect);
+            SDL_SetRenderDrawColor(renderer,255,255,255,255);
+            SDL_RenderDrawRect(renderer,&btn.rect);
+            int tx = btn.rect.x + (btn.rect.w - CustomCharacter::text_width(btn.text, scale))/2;
+            int ty = btn.rect.y + (btn.rect.h - 7*scale)/2;
+            CustomCharacter::draw_text(renderer, btn.text, tx, ty, white, scale);
+        }
+        SDL_RenderPresent(renderer);
+        SDL_Delay(16);
+    }
+    return result;
 }
 
 void SettingsMenu::show(SDL_Window *window, SDL_Renderer *renderer, int width, int height) {

--- a/src/Slider.cpp
+++ b/src/Slider.cpp
@@ -1,0 +1,55 @@
+#include "Slider.hpp"
+#include "CustomCharacter.hpp"
+#include <algorithm>
+
+Slider::Slider(const std::string &lab, const std::vector<std::string> &vals, int start)
+    : label(lab), values(vals), index(start), bar{0,0,100,10}, dragging(false) {}
+
+void Slider::set_rect(int x, int y, int w, int h) {
+    bar = {x, y, w, h};
+}
+
+void Slider::handle_event(const SDL_Event &e) {
+    if (e.type == SDL_MOUSEBUTTONDOWN && e.button.button == SDL_BUTTON_LEFT) {
+        if (e.button.x >= bar.x && e.button.x <= bar.x + bar.w &&
+            e.button.y >= bar.y - 5 && e.button.y <= bar.y + bar.h + 5) {
+            dragging = true;
+            double rel = double(e.button.x - bar.x) / double(bar.w);
+            int idx = int(rel * (values.size() - 1) + 0.5);
+            index = std::clamp(idx, 0, (int)values.size() - 1);
+        }
+    } else if (e.type == SDL_MOUSEBUTTONUP && e.button.button == SDL_BUTTON_LEFT) {
+        dragging = false;
+    } else if (e.type == SDL_MOUSEMOTION && dragging) {
+        double rel = double(e.motion.x - bar.x) / double(bar.w);
+        int idx = int(rel * (values.size() - 1) + 0.5);
+        index = std::clamp(idx, 0, (int)values.size() - 1);
+    }
+}
+
+void Slider::render(SDL_Renderer *renderer, int scale) const {
+    SDL_Color white{255,255,255,255};
+    // label
+    int label_width = CustomCharacter::text_width(label, scale);
+    CustomCharacter::draw_text(renderer, label, bar.x + bar.w/2 - label_width/2,
+                               bar.y - 20*scale, white, scale);
+    // bar line
+    SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
+    SDL_RenderDrawLine(renderer, bar.x, bar.y, bar.x + bar.w, bar.y);
+    if (values.size() > 1) {
+        double step = double(bar.w) / double(values.size() - 1);
+        for (size_t i=0;i<values.size();++i) {
+            int tx = bar.x + int(i*step);
+            SDL_RenderDrawLine(renderer, tx, bar.y-5*scale, tx, bar.y+5*scale);
+        }
+    }
+    // knob
+    double step = values.size() > 1 ? double(bar.w)/(values.size()-1) : 0;
+    int kx = bar.x + int(index * step);
+    SDL_Rect knob{kx-3*scale, bar.y-5*scale, 6*scale, 10*scale};
+    SDL_RenderFillRect(renderer, &knob);
+    // value text to right
+    const std::string &val = values[index];
+    CustomCharacter::draw_text(renderer, val, bar.x + bar.w + 10*scale,
+                               bar.y - 3*scale, white, scale);
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,7 @@
 #include "Application.hpp"
 #include "CommandLine.hpp"
 #include "MainMenu.hpp"
+#include "Settings.hpp"
 #include <string>
 
 /**
@@ -9,22 +10,27 @@
  */
 int main(int argc, char **argv)
 {
-	std::string scene_path;
-	int width;
-	int height;
-	char quality;
-	bool parsed;
-	parsed = parse_arguments(argc, argv, scene_path, width, height, quality);
-	if (!parsed)
-	{
-		return 1;
-	}
-	bool play;
-	play = MainMenu::show(width, height);
-	if (!play)
-	{
-		return 0;
-	}
-	run_application(scene_path, width, height, quality);
-	return 0;
+        std::string scene_path;
+        int width;
+        int height;
+        char quality;
+        bool parsed;
+        parsed = parse_arguments(argc, argv, scene_path, width, height, quality);
+        if (!parsed)
+        {
+                return 1;
+        }
+        load_settings("settings.yaml");
+        Settings &cfg = get_settings();
+        width = cfg.width;
+        height = cfg.height;
+        quality = cfg.quality;
+        bool play;
+        play = MainMenu::show(width, height);
+        if (!play)
+        {
+                return 0;
+        }
+        run_application(scene_path, cfg.width, cfg.height, cfg.quality);
+        return 0;
 }


### PR DESCRIPTION
## Summary
- Implement `ButtonsCluster` for mutually exclusive quality buttons and `Slider` widget for interactive settings
- Add persistent `Settings` system with YAML-style load/save and runtime application
- Wire up new `SettingsMenu` inheriting `AMenu`, including resolution and mouse sensitivity sliders, quality buttons, and apply/back actions
- Integrate settings loading at startup and sensitivity multiplier in renderer

## Testing
- `cmake .. && make -j2`


------
https://chatgpt.com/codex/tasks/task_e_68c18117b3c4832fbded4d328e790146