### PR TITLE
Add interactive settings menu with sliders and YAML persistence

### DIFF
--- a/inc/ButtonsCluster.hpp
+++ b/inc/ButtonsCluster.hpp
@@ -1,0 +1,27 @@
+#pragma once
+#include <SDL.h>
+#include <vector>
+#include <string>
+#include "Button.hpp"
+#include "CustomCharacter.hpp"
+
+// Group of buttons where only one button can be active at a time.
+class ButtonsCluster {
+public:
+    std::vector<Button> buttons;
+    int active; // index of currently active button
+    ButtonsCluster(const std::vector<std::string> &texts, int default_active = 0);
+
+    // Set rectangles for buttons placed horizontally starting at (x,y)
+    void set_layout(int x, int y, int button_width, int button_height, int gap);
+
+    // Handle mouse button events to change active button
+    void handle_event(const SDL_Event &e);
+
+    // Render the buttons cluster
+    void render(SDL_Renderer *renderer, int scale) const;
+
+    int active_index() const { return active; }
+    std::string active_text() const { return buttons[active].text; }
+};
+

--- a/inc/Settings.hpp
+++ b/inc/Settings.hpp
@@ -1,0 +1,20 @@
+#pragma once
+#include <string>
+
+// Structure holding configurable settings loaded from/saved to YAML.
+struct Settings {
+    char quality;           // 'L', 'M', 'H'
+    float mouse_sensitivity; // multiplier for MOUSE_SENSITIVITY
+    int width;              // window width
+    int height;             // window height
+};
+
+// Global settings instance used throughout the program.
+extern Settings g_settings;
+
+// Load settings from a YAML file. If the file does not exist, defaults are used.
+bool load_settings(Settings &out);
+
+// Save settings to a YAML file.
+void save_settings(const Settings &s);
+

--- a/inc/SettingsMenu.hpp
+++ b/inc/SettingsMenu.hpp
@@ -1,12 +1,25 @@
 #pragma once
 #include "AMenu.hpp"
+#include "ButtonsCluster.hpp"
+#include "Slider.hpp"
+#include "Settings.hpp"
 
 struct SDL_Window;
 struct SDL_Renderer;
 
 // Menu for adjusting settings
 class SettingsMenu : public AMenu {
+private:
+    ButtonsCluster quality_cluster;
+    Slider sensitivity_slider;
+    Slider resolution_slider;
+    Button back_button;
+    Button apply_button;
+
+    void run(SDL_Window *window, SDL_Renderer *renderer, int width, int height);
+
 public:
     SettingsMenu();
     static void show(SDL_Window *window, SDL_Renderer *renderer, int width, int height);
 };
+

--- a/inc/Slider.hpp
+++ b/inc/Slider.hpp
@@ -1,0 +1,29 @@
+#pragma once
+#include <SDL.h>
+#include <vector>
+#include <string>
+#include "CustomCharacter.hpp"
+
+// Slider widget allowing selection among discrete values.
+class Slider {
+public:
+    std::string label;
+    std::vector<std::string> values;
+    int index; // currently selected value index
+    SDL_Rect rect; // slider track rectangle
+    bool dragging;
+
+    Slider(const std::string &label, const std::vector<std::string> &vals, int default_index = 0);
+
+    // Update slider rect
+    void set_rect(int x, int y, int w, int h) { rect = {x, y, w, h}; }
+
+    // Handle SDL events to update slider position
+    void handle_event(const SDL_Event &e);
+
+    // Render slider with ticks and handle; value displayed to right
+    void render(SDL_Renderer *renderer, int scale) const;
+
+    std::string current_value() const { return values[index]; }
+};
+

--- a/src/AMenu.cpp
+++ b/src/AMenu.cpp
@@ -49,11 +49,8 @@ ButtonAction AMenu::run(SDL_Window *window, SDL_Renderer *renderer, int width, i
                 for (auto &btn : buttons) {
                     if (mx >= btn.rect.x && mx < btn.rect.x + btn.rect.w &&
                         my >= btn.rect.y && my < btn.rect.y + btn.rect.h) {
-                        if (btn.action != ButtonAction::Settings &&
-                            btn.action != ButtonAction::Leaderboard) {
-                            result = btn.action;
-                            running = false;
-                        }
+                        result = btn.action;
+                        running = false;
                         break;
                     }
                 }

--- a/src/ButtonsCluster.cpp
+++ b/src/ButtonsCluster.cpp
@@ -1,0 +1,51 @@
+#include "ButtonsCluster.hpp"
+
+ButtonsCluster::ButtonsCluster(const std::vector<std::string> &texts, int default_active)
+    : active(default_active) {
+    for (auto &t : texts) {
+        buttons.push_back(Button{t, ButtonAction::None, SDL_Color{0, 0, 0, 255}});
+    }
+    if (active < 0 || active >= static_cast<int>(buttons.size()))
+        active = 0;
+}
+
+void ButtonsCluster::set_layout(int x, int y, int button_width, int button_height, int gap) {
+    for (std::size_t i = 0; i < buttons.size(); ++i) {
+        buttons[i].rect = {x + static_cast<int>(i) * (button_width + gap), y, button_width, button_height};
+    }
+}
+
+void ButtonsCluster::handle_event(const SDL_Event &e) {
+    if (e.type == SDL_MOUSEBUTTONDOWN && e.button.button == SDL_BUTTON_LEFT) {
+        int mx = e.button.x;
+        int my = e.button.y;
+        for (std::size_t i = 0; i < buttons.size(); ++i) {
+            const SDL_Rect &r = buttons[i].rect;
+            if (mx >= r.x && mx < r.x + r.w && my >= r.y && my < r.y + r.h) {
+                active = static_cast<int>(i);
+                break;
+            }
+        }
+    }
+}
+
+void ButtonsCluster::render(SDL_Renderer *renderer, int scale) const {
+    SDL_Color white{255, 255, 255, 255};
+    SDL_Color black{0, 0, 0, 255};
+    int mx, my;
+    SDL_GetMouseState(&mx, &my);
+    for (std::size_t i = 0; i < buttons.size(); ++i) {
+        const SDL_Rect &r = buttons[i].rect;
+        bool hover = mx >= r.x && mx < r.x + r.w && my >= r.y && my < r.y + r.h;
+        SDL_Color fill = (static_cast<int>(i) == active) ? white : (hover ? buttons[i].hover_color : SDL_Color{0, 0, 0, 255});
+        SDL_SetRenderDrawColor(renderer, fill.r, fill.g, fill.b, fill.a);
+        SDL_RenderFillRect(renderer, &r);
+        SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
+        SDL_RenderDrawRect(renderer, &r);
+        SDL_Color text_color = (static_cast<int>(i) == active) ? black : white;
+        int text_x = r.x + (r.w - CustomCharacter::text_width(buttons[i].text, scale)) / 2;
+        int text_y = r.y + (r.h - 7 * scale) / 2;
+        CustomCharacter::draw_text(renderer, buttons[i].text, text_x, text_y, text_color, scale);
+    }
+}
+

--- a/src/MainMenu.cpp
+++ b/src/MainMenu.cpp
@@ -1,4 +1,6 @@
 #include "MainMenu.hpp"
+#include "LeaderboardMenu.hpp"
+#include "SettingsMenu.hpp"
 #include <SDL.h>
 
 MainMenu::MainMenu() : AMenu("MINIRT THE GAME") {
@@ -25,9 +27,23 @@ bool MainMenu::show(int width, int height) {
         return false;
     }
     MainMenu menu;
-    ButtonAction action = menu.run(window, renderer, width, height);
+    bool play = false;
+    bool quit = false;
+    while (!quit && !play) {
+        ButtonAction action = menu.run(window, renderer, width, height);
+        if (action == ButtonAction::Play) {
+            play = true;
+        } else if (action == ButtonAction::Quit) {
+            quit = true;
+        } else if (action == ButtonAction::Settings) {
+            SettingsMenu::show(window, renderer, width, height);
+            SDL_GetWindowSize(window, &width, &height);
+        } else if (action == ButtonAction::Leaderboard) {
+            LeaderboardMenu::show(window, renderer, width, height);
+        }
+    }
     SDL_DestroyRenderer(renderer);
     SDL_DestroyWindow(window);
     SDL_Quit();
-    return action == ButtonAction::Play;
+    return play;
 }

--- a/src/PauseMenu.cpp
+++ b/src/PauseMenu.cpp
@@ -1,4 +1,7 @@
 #include "PauseMenu.hpp"
+#include "LeaderboardMenu.hpp"
+#include "SettingsMenu.hpp"
+#include <SDL.h>
 
 PauseMenu::PauseMenu() : AMenu("PAUSE") {
     title_colors.assign(title.size(), SDL_Color{255, 255, 255, 255});
@@ -10,6 +13,17 @@ PauseMenu::PauseMenu() : AMenu("PAUSE") {
 
 bool PauseMenu::show(SDL_Window *window, SDL_Renderer *renderer, int width, int height) {
     PauseMenu menu;
-    ButtonAction action = menu.run(window, renderer, width, height);
-    return action == ButtonAction::Resume;
+    while (true) {
+        ButtonAction action = menu.run(window, renderer, width, height);
+        if (action == ButtonAction::Resume)
+            return true;
+        if (action == ButtonAction::Quit)
+            return false;
+        if (action == ButtonAction::Settings) {
+            SettingsMenu::show(window, renderer, width, height);
+            SDL_GetWindowSize(window, &width, &height);
+        } else if (action == ButtonAction::Leaderboard) {
+            LeaderboardMenu::show(window, renderer, width, height);
+        }
+    }
 }

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -1,6 +1,7 @@
 #include "Renderer.hpp"
 #include "AABB.hpp"
 #include "Config.hpp"
+#include "Settings.hpp"
 #include "Parser.hpp"
 #include "PauseMenu.hpp"
 #include <SDL.h>
@@ -308,7 +309,7 @@ void Renderer::process_events(RenderState &st, SDL_Window *win, SDL_Renderer *re
                 {
                         if (st.edit_mode && st.rotating)
                         {
-                                double sens = MOUSE_SENSITIVITY;
+                                double sens = MOUSE_SENSITIVITY * g_settings.mouse_sensitivity;
                                 bool changed = false;
                                 double yaw = -e.motion.xrel * sens;
                                 if (yaw != 0.0)
@@ -339,7 +340,7 @@ void Renderer::process_events(RenderState &st, SDL_Window *win, SDL_Renderer *re
                         }
                         else
                         {
-                                double sens = MOUSE_SENSITIVITY;
+                                double sens = MOUSE_SENSITIVITY * g_settings.mouse_sensitivity;
                                 cam.rotate(-e.motion.xrel * sens,
                                                    -e.motion.yrel * sens);
                         }

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -1,0 +1,67 @@
+#include "Settings.hpp"
+#include <fstream>
+#include <sstream>
+
+Settings g_settings{'H', 1.0f, 1080, 720};
+
+static std::string trim(const std::string &s) {
+    size_t start = s.find_first_not_of(" \t\r\n");
+    size_t end = s.find_last_not_of(" \t\r\n");
+    if (start == std::string::npos || end == std::string::npos)
+        return "";
+    return s.substr(start, end - start + 1);
+}
+
+bool load_settings(Settings &out) {
+    Settings defaults{'H', 1.0f, 1080, 720};
+    std::ifstream file("settings.yaml");
+    if (!file) {
+        out = defaults;
+        g_settings = defaults;
+        return false;
+    }
+    Settings s = defaults;
+    std::string line;
+    while (std::getline(file, line)) {
+        std::size_t colon = line.find(':');
+        if (colon == std::string::npos)
+            continue;
+        std::string key = trim(line.substr(0, colon));
+        std::string value = trim(line.substr(colon + 1));
+        if (key == "quality") {
+            if (value == "Low" || value == "low")
+                s.quality = 'L';
+            else if (value == "Medium" || value == "medium")
+                s.quality = 'M';
+            else
+                s.quality = 'H';
+        } else if (key == "mouse_sensitivity") {
+            s.mouse_sensitivity = std::stof(value);
+        } else if (key == "resolution") {
+            std::size_t x = value.find('x');
+            if (x != std::string::npos) {
+                s.width = std::stoi(value.substr(0, x));
+                s.height = std::stoi(value.substr(x + 1));
+            }
+        }
+    }
+    out = s;
+    g_settings = s;
+    return true;
+}
+
+void save_settings(const Settings &s) {
+    std::ofstream file("settings.yaml");
+    if (!file)
+        return;
+    std::string quality;
+    switch (s.quality) {
+    case 'L': quality = "Low"; break;
+    case 'M': quality = "Medium"; break;
+    default: quality = "High"; break;
+    }
+    file << "quality: " << quality << "\n";
+    file << "mouse_sensitivity: " << s.mouse_sensitivity << "\n";
+    file << "resolution: " << s.width << "x" << s.height << "\n";
+}
+

--- a/src/SettingsMenu.cpp
+++ b/src/SettingsMenu.cpp
@@ -1,10 +1,162 @@
 #include "SettingsMenu.hpp"
+#include <SDL.h>
+#include <iomanip>
+#include <sstream>
 
-SettingsMenu::SettingsMenu() : AMenu("SETTINGS") {
-    buttons.push_back(Button{"BACK", ButtonAction::Back, SDL_Color{255, 0, 0, 255}});
+static std::vector<std::string> build_sens_values() {
+    std::vector<std::string> vals;
+    for (int i = 1; i <= 20; ++i) {
+        std::ostringstream ss;
+        ss << std::fixed << std::setprecision(1) << i / 10.0f;
+        vals.push_back(ss.str());
+    }
+    return vals;
 }
+
+static int resolution_index_from_settings() {
+    if (g_settings.width == 720 && g_settings.height == 480)
+        return 0;
+    if (g_settings.width == 1080 && g_settings.height == 720)
+        return 1;
+    if (g_settings.width == 1366 && g_settings.height == 768)
+        return 2;
+    return 3;
+}
+
+SettingsMenu::SettingsMenu()
+    : AMenu("SETTINGS"),
+      quality_cluster({"LOW", "MEDIUM", "HIGH"}, g_settings.quality == 'L' ? 0 : (g_settings.quality == 'M' ? 1 : 2)),
+      sensitivity_slider("MOUSE SENSITIVITY", build_sens_values(),
+                         static_cast<int>(g_settings.mouse_sensitivity * 10) - 1),
+      resolution_slider("RESOLUTION", {"720x480", "1080x720", "1366x768", "1920x1080"},
+                        resolution_index_from_settings()),
+      back_button{"BACK", ButtonAction::Back, SDL_Color{255, 0, 0, 255}},
+      apply_button{"APPLY", ButtonAction::None, SDL_Color{0, 255, 0, 255}} {}
 
 void SettingsMenu::show(SDL_Window *window, SDL_Renderer *renderer, int width, int height) {
     SettingsMenu menu;
     menu.run(window, renderer, width, height);
 }
+
+void SettingsMenu::run(SDL_Window *window, SDL_Renderer *renderer, int width, int height) {
+    bool running = true;
+    SDL_Color white{255, 255, 255, 255};
+
+    while (running) {
+        SDL_GetWindowSize(window, &width, &height);
+        float scale_factor = static_cast<float>(height) / 600.0f;
+        int button_width = static_cast<int>(300 * scale_factor);
+        int button_height = static_cast<int>(100 * scale_factor);
+        int button_gap = static_cast<int>(10 * scale_factor);
+        int scale = static_cast<int>(4 * scale_factor);
+        if (scale < 1)
+            scale = 1;
+        int title_scale = scale * 2;
+        int title_height = 7 * title_scale;
+        int title_y = static_cast<int>(20 * scale_factor);
+        int title_x = width / 2 - CustomCharacter::text_width(title, title_scale) / 2;
+
+        int y = title_y + title_height + static_cast<int>(40 * scale_factor);
+        int center_x = width / 2 - button_width / 2;
+
+        // Quality section
+        int quality_label_x = width / 2 - CustomCharacter::text_width("QUALITY", scale) / 2;
+        int quality_label_y = y;
+        y += 7 * scale + button_gap;
+        int cluster_button_width = (button_width - 2 * button_gap) / 3;
+        quality_cluster.set_layout(center_x, y, cluster_button_width, button_height, button_gap);
+        y += button_height + button_gap * 2;
+
+        // Sensitivity slider
+        int sens_label_y = y;
+        y += 7 * scale + button_gap;
+        sensitivity_slider.set_rect(center_x, y + button_height / 2 - scale / 2, button_width, scale);
+        y += button_height + button_gap * 2;
+
+        // Resolution slider
+        int res_label_y = y;
+        y += 7 * scale + button_gap;
+        resolution_slider.set_rect(center_x, y + button_height / 2 - scale / 2, button_width, scale);
+        y += button_height + button_gap * 2;
+
+        // Bottom buttons
+        int half_width = (button_width - button_gap) / 2;
+        back_button.rect = {center_x, y, half_width, button_height};
+        apply_button.rect = {center_x + half_width + button_gap, y, half_width, button_height};
+
+        SDL_Event e;
+        while (SDL_PollEvent(&e)) {
+            if (e.type == SDL_QUIT) {
+                running = false;
+            }
+            quality_cluster.handle_event(e);
+            sensitivity_slider.handle_event(e);
+            resolution_slider.handle_event(e);
+            if (e.type == SDL_MOUSEBUTTONDOWN && e.button.button == SDL_BUTTON_LEFT) {
+                int mx = e.button.x;
+                int my = e.button.y;
+                if (mx >= back_button.rect.x && mx < back_button.rect.x + back_button.rect.w &&
+                    my >= back_button.rect.y && my < back_button.rect.y + back_button.rect.h) {
+                    running = false; // back
+                } else if (mx >= apply_button.rect.x && mx < apply_button.rect.x + apply_button.rect.w &&
+                           my >= apply_button.rect.y && my < apply_button.rect.y + apply_button.rect.h) {
+                    // apply settings
+                    int qidx = quality_cluster.active_index();
+                    g_settings.quality = (qidx == 0 ? 'L' : (qidx == 1 ? 'M' : 'H'));
+                    g_settings.mouse_sensitivity = std::stof(sensitivity_slider.current_value());
+                    std::string res = resolution_slider.current_value();
+                    std::size_t x = res.find('x');
+                    if (x != std::string::npos) {
+                        g_settings.width = std::stoi(res.substr(0, x));
+                        g_settings.height = std::stoi(res.substr(x + 1));
+                        SDL_SetWindowSize(window, g_settings.width, g_settings.height);
+                    }
+                    save_settings(g_settings);
+                    running = false;
+                }
+            }
+        }
+
+        SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
+        SDL_RenderClear(renderer);
+
+        // Title
+        CustomCharacter::draw_text(renderer, title, title_x, title_y, white, title_scale);
+
+        // Labels
+        CustomCharacter::draw_text(renderer, "QUALITY", quality_label_x, quality_label_y, white, scale);
+        CustomCharacter::draw_text(renderer, "MOUSE SENSITIVITY", center_x + (button_width - CustomCharacter::text_width("MOUSE SENSITIVITY", scale)) / 2,
+                                   sens_label_y, white, scale);
+        CustomCharacter::draw_text(renderer, "RESOLUTION", center_x + (button_width - CustomCharacter::text_width("RESOLUTION", scale)) / 2,
+                                   res_label_y, white, scale);
+
+        // Widgets
+        quality_cluster.render(renderer, scale);
+        sensitivity_slider.render(renderer, scale);
+        resolution_slider.render(renderer, scale);
+
+        // Back and Apply buttons
+        int mx, my;
+        SDL_GetMouseState(&mx, &my);
+        Button *btns[2] = {&back_button, &apply_button};
+        for (Button *btn : btns) {
+            bool hover = mx >= btn->rect.x && mx < btn->rect.x + btn->rect.w &&
+                         my >= btn->rect.y && my < btn->rect.y + btn->rect.h;
+            SDL_Color fill = hover ? btn->hover_color : SDL_Color{0, 0, 0, 255};
+            SDL_SetRenderDrawColor(renderer, fill.r, fill.g, fill.b, fill.a);
+            SDL_RenderFillRect(renderer, &btn->rect);
+            SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
+            SDL_RenderDrawRect(renderer, &btn->rect);
+            int text_x = btn->rect.x + (btn->rect.w - CustomCharacter::text_width(btn->text, scale)) / 2;
+            int text_y = btn->rect.y + (btn->rect.h - 7 * scale) / 2;
+            SDL_Color tc = white;
+            if (btn == &apply_button && hover)
+                tc = white;
+            CustomCharacter::draw_text(renderer, btn->text, text_x, text_y, tc, scale);
+        }
+
+        SDL_RenderPresent(renderer);
+        SDL_Delay(16);
+    }
+}
+

--- a/src/Slider.cpp
+++ b/src/Slider.cpp
@@ -1,0 +1,65 @@
+#include "Slider.hpp"
+#include <cmath>
+
+Slider::Slider(const std::string &l, const std::vector<std::string> &vals, int default_index)
+    : label(l), values(vals), index(default_index), rect{0, 0, 0, 0}, dragging(false) {
+    if (index < 0 || index >= static_cast<int>(values.size()))
+        index = 0;
+}
+
+void Slider::handle_event(const SDL_Event &e) {
+    auto update_index = [this](int mx) {
+        if (rect.w <= 0 || values.empty())
+            return;
+        int rel = mx - rect.x;
+        if (rel < 0)
+            rel = 0;
+        if (rel > rect.w)
+            rel = rect.w;
+        double ratio = static_cast<double>(rel) / static_cast<double>(rect.w);
+        index = static_cast<int>(std::round(ratio * (values.size() - 1)));
+    };
+    if (e.type == SDL_MOUSEBUTTONDOWN && e.button.button == SDL_BUTTON_LEFT) {
+        int mx = e.button.x;
+        int my = e.button.y;
+        if (mx >= rect.x && mx <= rect.x + rect.w && my >= rect.y - 5 && my <= rect.y + rect.h + 5) {
+            dragging = true;
+            update_index(mx);
+        }
+    } else if (e.type == SDL_MOUSEBUTTONUP && e.button.button == SDL_BUTTON_LEFT) {
+        dragging = false;
+    } else if (e.type == SDL_MOUSEMOTION && dragging) {
+        update_index(e.motion.x);
+    }
+}
+
+void Slider::render(SDL_Renderer *renderer, int scale) const {
+    SDL_Color white{255, 255, 255, 255};
+    int track_y = rect.y + rect.h / 2;
+    SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
+    SDL_RenderDrawLine(renderer, rect.x, track_y, rect.x + rect.w, track_y);
+    // ticks
+    if (values.size() > 1) {
+        for (std::size_t i = 0; i < values.size(); ++i) {
+            int x = rect.x + static_cast<int>((static_cast<double>(i) / (values.size() - 1)) * rect.w);
+            SDL_RenderDrawLine(renderer, x, track_y - scale, x, track_y + scale);
+        }
+    }
+    // handle
+    int handle_x = rect.x;
+    if (values.size() > 1)
+        handle_x += static_cast<int>((static_cast<double>(index) / (values.size() - 1)) * rect.w);
+    SDL_Rect handle_rect{handle_x - scale, track_y - scale, 2 * scale, 2 * scale};
+    SDL_SetRenderDrawColor(renderer, 255, 0, 0, 255);
+    SDL_RenderFillRect(renderer, &handle_rect);
+    // label
+    int label_x = rect.x + (rect.w - CustomCharacter::text_width(label, scale)) / 2;
+    int label_y = rect.y - 7 * scale - scale;
+    CustomCharacter::draw_text(renderer, label, label_x, label_y, white, scale);
+    // value
+    std::string val = values[index];
+    int val_x = rect.x + rect.w + scale * 2;
+    int val_y = track_y - 3 * scale;
+    CustomCharacter::draw_text(renderer, val, val_x, val_y, white, scale);
+}
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,7 @@
 #include "Application.hpp"
 #include "CommandLine.hpp"
 #include "MainMenu.hpp"
+#include "Settings.hpp"
 #include <string>
 
 /**
@@ -13,18 +14,26 @@ int main(int argc, char **argv)
 	int width;
 	int height;
 	char quality;
-	bool parsed;
-	parsed = parse_arguments(argc, argv, scene_path, width, height, quality);
-	if (!parsed)
-	{
-		return 1;
-	}
-	bool play;
-	play = MainMenu::show(width, height);
-	if (!play)
-	{
-		return 0;
-	}
-	run_application(scene_path, width, height, quality);
-	return 0;
+        bool parsed;
+        parsed = parse_arguments(argc, argv, scene_path, width, height, quality);
+        if (!parsed)
+        {
+                return 1;
+        }
+        Settings file_settings;
+        load_settings(file_settings);
+        width = file_settings.width;
+        height = file_settings.height;
+        quality = file_settings.quality;
+        bool play;
+        play = MainMenu::show(width, height);
+        if (!play)
+        {
+                return 0;
+        }
+        width = g_settings.width;
+        height = g_settings.height;
+        quality = g_settings.quality;
+        run_application(scene_path, width, height, quality);
+        return 0;
 }


### PR DESCRIPTION
## Summary
- add settings storage and YAML import/export
- build slider and buttons cluster UI widgets
- implement full settings menu with quality, sensitivity, and resolution controls
- integrate settings menu into main and pause flows and apply mouse sensitivity scaling

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68c18117b3c4832fbded4d328e790146