### PR TITLE
Add settings menu with initial sections and quality controls

### DIFF
--- a/inc/ButtonsCluster.hpp
+++ b/inc/ButtonsCluster.hpp
@@ -1,0 +1,18 @@
+#pragma once
+#include <vector>
+#include <string>
+#include <SDL.h>
+#include "Button.hpp"
+#include "CustomCharacter.hpp"
+
+class ButtonsCluster {
+    std::vector<Button> buttons;
+    int active_index;
+
+public:
+    explicit ButtonsCluster(const std::vector<std::string> &labels);
+    void layout(int x, int y, int width, int height);
+    void render(SDL_Renderer *renderer, int scale) const;
+    void handle_event(const SDL_Event &event);
+};
+

--- a/inc/SettingsMenu.hpp
+++ b/inc/SettingsMenu.hpp
@@ -1,12 +1,20 @@
 #pragma once
 #include "AMenu.hpp"
+#include "SettingsSection.hpp"
 
 struct SDL_Window;
 struct SDL_Renderer;
 
 // Menu for adjusting settings
 class SettingsMenu : public AMenu {
+    QualitySection quality;
+    MouseSensitivitySection mouse;
+    ResolutionSection resolution;
+
 public:
     SettingsMenu();
     static void show(SDL_Window *window, SDL_Renderer *renderer, int width, int height);
+
+private:
+    ButtonAction run(SDL_Window *window, SDL_Renderer *renderer, int width, int height);
 };

--- a/inc/SettingsSection.hpp
+++ b/inc/SettingsSection.hpp
@@ -1,0 +1,42 @@
+#pragma once
+#include <SDL.h>
+#include <string>
+#include "ButtonsCluster.hpp"
+#include "CustomCharacter.hpp"
+
+class SettingsSection {
+protected:
+    std::string label;
+    SDL_Rect area;
+
+public:
+    explicit SettingsSection(const std::string &l);
+    virtual ~SettingsSection() = default;
+    void set_area(int x, int y, int w, int h);
+    virtual void layout(int scale);
+    virtual void render(SDL_Renderer *renderer, int scale) const = 0;
+    virtual void handle_event(const SDL_Event &event);
+};
+
+class QualitySection : public SettingsSection {
+    ButtonsCluster cluster;
+
+public:
+    QualitySection();
+    void layout(int scale) override;
+    void render(SDL_Renderer *renderer, int scale) const override;
+    void handle_event(const SDL_Event &event) override;
+};
+
+class MouseSensitivitySection : public SettingsSection {
+public:
+    MouseSensitivitySection();
+    void render(SDL_Renderer *renderer, int scale) const override;
+};
+
+class ResolutionSection : public SettingsSection {
+public:
+    ResolutionSection();
+    void render(SDL_Renderer *renderer, int scale) const override;
+};
+

--- a/src/AMenu.cpp
+++ b/src/AMenu.cpp
@@ -1,4 +1,6 @@
 #include "AMenu.hpp"
+#include "SettingsMenu.hpp"
+#include "LeaderboardMenu.hpp"
 
 AMenu::AMenu(const std::string &t) : title(t) {}
 
@@ -49,8 +51,11 @@ ButtonAction AMenu::run(SDL_Window *window, SDL_Renderer *renderer, int width, i
                 for (auto &btn : buttons) {
                     if (mx >= btn.rect.x && mx < btn.rect.x + btn.rect.w &&
                         my >= btn.rect.y && my < btn.rect.y + btn.rect.h) {
-                        if (btn.action != ButtonAction::Settings &&
-                            btn.action != ButtonAction::Leaderboard) {
+                        if (btn.action == ButtonAction::Settings) {
+                            SettingsMenu::show(window, renderer, width, height);
+                        } else if (btn.action == ButtonAction::Leaderboard) {
+                            LeaderboardMenu::show(window, renderer, width, height);
+                        } else {
                             result = btn.action;
                             running = false;
                         }

--- a/src/ButtonsCluster.cpp
+++ b/src/ButtonsCluster.cpp
@@ -1,0 +1,53 @@
+#include "ButtonsCluster.hpp"
+
+ButtonsCluster::ButtonsCluster(const std::vector<std::string> &labels)
+    : active_index(-1) {
+    for (const auto &l : labels) {
+        buttons.emplace_back(l, ButtonAction::None, SDL_Color{255, 255, 255, 255});
+    }
+}
+
+void ButtonsCluster::layout(int x, int y, int width, int height) {
+    int count = static_cast<int>(buttons.size());
+    int gap = 10;
+    int total_gap = gap * (count - 1);
+    int button_w = (width - total_gap) / count;
+    for (int i = 0; i < count; ++i) {
+        buttons[i].rect = {x + i * (button_w + gap), y, button_w, height};
+    }
+}
+
+void ButtonsCluster::render(SDL_Renderer *renderer, int scale) const {
+    for (int i = 0; i < static_cast<int>(buttons.size()); ++i) {
+        const SDL_Rect &r = buttons[i].rect;
+        bool pressed = (i == active_index);
+        SDL_Color fill = pressed ? SDL_Color{255, 255, 255, 255}
+                                 : SDL_Color{0, 0, 0, 255};
+        SDL_Color text_color = pressed ? SDL_Color{0, 0, 0, 255}
+                                       : SDL_Color{255, 255, 255, 255};
+        SDL_SetRenderDrawColor(renderer, fill.r, fill.g, fill.b, fill.a);
+        SDL_RenderFillRect(renderer, &r);
+        SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
+        SDL_RenderDrawRect(renderer, &r);
+        int text_x =
+            r.x + (r.w - CustomCharacter::text_width(buttons[i].text, scale)) / 2;
+        int text_y = r.y + (r.h - 7 * scale) / 2;
+        CustomCharacter::draw_text(renderer, buttons[i].text, text_x, text_y,
+                                   text_color, scale);
+    }
+}
+
+void ButtonsCluster::handle_event(const SDL_Event &event) {
+    if (event.type == SDL_MOUSEBUTTONDOWN &&
+        event.button.button == SDL_BUTTON_LEFT) {
+        int mx = event.button.x;
+        int my = event.button.y;
+        for (int i = 0; i < static_cast<int>(buttons.size()); ++i) {
+            const SDL_Rect &r = buttons[i].rect;
+            if (mx >= r.x && mx < r.x + r.w && my >= r.y && my < r.y + r.h) {
+                active_index = i;
+            }
+        }
+    }
+}
+

--- a/src/SettingsMenu.cpp
+++ b/src/SettingsMenu.cpp
@@ -1,10 +1,128 @@
 #include "SettingsMenu.hpp"
 
-SettingsMenu::SettingsMenu() : AMenu("SETTINGS") {
+SettingsMenu::SettingsMenu() : AMenu("SETTINGS"), quality(), mouse(), resolution() {
     buttons.push_back(Button{"BACK", ButtonAction::Back, SDL_Color{255, 0, 0, 255}});
+    buttons.push_back(Button{"APPLY", ButtonAction::None, SDL_Color{0, 255, 0, 255}});
 }
 
-void SettingsMenu::show(SDL_Window *window, SDL_Renderer *renderer, int width, int height) {
+void SettingsMenu::show(SDL_Window *window, SDL_Renderer *renderer, int width,
+                        int height) {
     SettingsMenu menu;
     menu.run(window, renderer, width, height);
 }
+
+ButtonAction SettingsMenu::run(SDL_Window *window, SDL_Renderer *renderer,
+                               int width, int height) {
+    bool running = true;
+    ButtonAction result = ButtonAction::None;
+    SDL_Color white{255, 255, 255, 255};
+
+    while (running) {
+        SDL_GetWindowSize(window, &width, &height);
+        float scale_factor = static_cast<float>(height) / 600.0f;
+        int button_width = static_cast<int>(300 * scale_factor);
+        int button_height = static_cast<int>(100 * scale_factor);
+        int button_gap = static_cast<int>(10 * scale_factor);
+        int scale = static_cast<int>(4 * scale_factor);
+        if (scale < 1)
+            scale = 1;
+        int title_scale = scale * 2;
+        int title_height = 7 * title_scale;
+        int title_gap = static_cast<int>(40 * scale_factor);
+        int section_height = static_cast<int>(80 * scale_factor);
+        int section_gap = static_cast<int>(20 * scale_factor);
+        int sections_total_height = section_height * 3 + section_gap * 2 + button_height;
+        int top_margin =
+            (height - title_height - title_gap - sections_total_height) / 2;
+        if (top_margin < 0)
+            top_margin = 0;
+
+        int title_x = width / 2 - CustomCharacter::text_width(title, title_scale) / 2;
+        int title_y = top_margin;
+
+        int section_width = static_cast<int>(width * 0.6f);
+        int section_x = width / 2 - section_width / 2;
+        int current_y = title_y + title_height + title_gap;
+
+        quality.set_area(section_x, current_y, section_width, section_height);
+        quality.layout(scale);
+        current_y += section_height + section_gap;
+
+        mouse.set_area(section_x, current_y, section_width, section_height);
+        mouse.layout(scale);
+        current_y += section_height + section_gap;
+
+        resolution.set_area(section_x, current_y, section_width, section_height);
+        resolution.layout(scale);
+        current_y += section_height + section_gap;
+
+        buttons[0].rect = {width / 2 - button_width - button_gap / 2, current_y,
+                           button_width, button_height};
+        buttons[1].rect = {width / 2 + button_gap / 2, current_y, button_width,
+                           button_height};
+
+        SDL_Event event;
+        while (SDL_PollEvent(&event)) {
+            if (event.type == SDL_QUIT) {
+                running = false;
+                result = ButtonAction::Quit;
+            } else if (event.type == SDL_MOUSEBUTTONDOWN &&
+                       event.button.button == SDL_BUTTON_LEFT) {
+                int mx = event.button.x;
+                int my = event.button.y;
+                if (mx >= buttons[0].rect.x &&
+                    mx < buttons[0].rect.x + buttons[0].rect.w &&
+                    my >= buttons[0].rect.y &&
+                    my < buttons[0].rect.y + buttons[0].rect.h) {
+                    result = ButtonAction::Back;
+                    running = false;
+                } else if (mx >= buttons[1].rect.x &&
+                           mx < buttons[1].rect.x + buttons[1].rect.w &&
+                           my >= buttons[1].rect.y &&
+                           my < buttons[1].rect.y + buttons[1].rect.h) {
+                    // Apply button placeholder
+                }
+            }
+            quality.handle_event(event);
+        }
+
+        int mx, my;
+        SDL_GetMouseState(&mx, &my);
+
+        SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
+        SDL_RenderClear(renderer);
+
+        int tx = title_x;
+        for (char c : title) {
+            CustomCharacter::draw_character(renderer, c, tx, title_y, white,
+                                            title_scale);
+            tx += (5 + 1) * title_scale;
+        }
+
+        quality.render(renderer, scale);
+        mouse.render(renderer, scale);
+        resolution.render(renderer, scale);
+
+        for (auto &btn : buttons) {
+            bool hover = mx >= btn.rect.x && mx < btn.rect.x + btn.rect.w &&
+                         my >= btn.rect.y && my < btn.rect.y + btn.rect.h;
+            SDL_Color fill = hover ? btn.hover_color : SDL_Color{0, 0, 0, 255};
+            SDL_SetRenderDrawColor(renderer, fill.r, fill.g, fill.b, fill.a);
+            SDL_RenderFillRect(renderer, &btn.rect);
+            SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
+            SDL_RenderDrawRect(renderer, &btn.rect);
+            int text_x =
+                btn.rect.x +
+                (btn.rect.w - CustomCharacter::text_width(btn.text, scale)) / 2;
+            int text_y = btn.rect.y + (btn.rect.h - 7 * scale) / 2;
+            CustomCharacter::draw_text(renderer, btn.text, text_x, text_y, white,
+                                       scale);
+        }
+
+        SDL_RenderPresent(renderer);
+        SDL_Delay(16);
+    }
+
+    return result;
+}
+

--- a/src/SettingsSection.cpp
+++ b/src/SettingsSection.cpp
@@ -1,0 +1,64 @@
+#include "SettingsSection.hpp"
+
+SettingsSection::SettingsSection(const std::string &l)
+    : label(l), area{0, 0, 0, 0} {}
+
+void SettingsSection::set_area(int x, int y, int w, int h) {
+    area = SDL_Rect{x, y, w, h};
+}
+
+void SettingsSection::layout(int) {}
+
+void SettingsSection::handle_event(const SDL_Event &) {}
+
+QualitySection::QualitySection()
+    : SettingsSection("QUALITY"), cluster({"LOW", "MEDIUM", "HIGH"}) {}
+
+void QualitySection::layout(int scale) {
+    int label_height = 7 * scale;
+    int content_y = area.y + label_height + 10 * scale;
+    int content_height = area.h - (content_y - area.y);
+    cluster.layout(area.x, content_y, area.w, content_height);
+}
+
+void QualitySection::render(SDL_Renderer *renderer, int scale) const {
+    SDL_Color white{255, 255, 255, 255};
+    int label_width = CustomCharacter::text_width(label, scale);
+    int label_x = area.x + (area.w - label_width) / 2;
+    CustomCharacter::draw_text(renderer, label, label_x, area.y, white, scale);
+    cluster.render(renderer, scale);
+}
+
+void QualitySection::handle_event(const SDL_Event &event) {
+    cluster.handle_event(event);
+}
+
+MouseSensitivitySection::MouseSensitivitySection()
+    : SettingsSection("MOUSE SENSITIVITY") {}
+
+void MouseSensitivitySection::render(SDL_Renderer *renderer, int scale) const {
+    SDL_Color white{255, 255, 255, 255};
+    int label_width = CustomCharacter::text_width(label, scale);
+    int label_x = area.x + (area.w - label_width) / 2;
+    CustomCharacter::draw_text(renderer, label, label_x, area.y, white, scale);
+    int label_height = 7 * scale;
+    SDL_Rect placeholder{area.x, area.y + label_height + 10 * scale, area.w,
+                         area.h - label_height - 10 * scale};
+    SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
+    SDL_RenderDrawRect(renderer, &placeholder);
+}
+
+ResolutionSection::ResolutionSection() : SettingsSection("RESOLUTION") {}
+
+void ResolutionSection::render(SDL_Renderer *renderer, int scale) const {
+    SDL_Color white{255, 255, 255, 255};
+    int label_width = CustomCharacter::text_width(label, scale);
+    int label_x = area.x + (area.w - label_width) / 2;
+    CustomCharacter::draw_text(renderer, label, label_x, area.y, white, scale);
+    int label_height = 7 * scale;
+    SDL_Rect placeholder{area.x, area.y + label_height + 10 * scale, area.w,
+                         area.h - label_height - 10 * scale};
+    SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
+    SDL_RenderDrawRect(renderer, &placeholder);
+}
+


### PR DESCRIPTION
## Summary
- Implement a dedicated `SettingsMenu` with quality selection, sensitivity and resolution sections
- Add reusable `ButtonsCluster` and `SettingsSection` helpers for building menu sections
- Trigger settings and leaderboard menus from any menu when their buttons are pressed

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "SDL2")*


------
https://chatgpt.com/codex/tasks/task_e_68c2826d9e6c832f9737c85dd0483df5