### PR TITLE
Add settings menu with sections and quality toggle

### DIFF
--- a/inc/ButtonsCluster.hpp
+++ b/inc/ButtonsCluster.hpp
@@ -1,0 +1,27 @@
+#pragma once
+#include <SDL.h>
+#include <string>
+#include <vector>
+#include "Button.hpp"
+#include "CustomCharacter.hpp"
+
+// Cluster of buttons acting as a switch group
+class ButtonsCluster {
+private:
+    std::vector<Button> buttons;
+    int selected;
+
+public:
+    explicit ButtonsCluster(const std::vector<std::string> &names);
+
+    // Arrange buttons within given rectangle
+    void layout(int x, int y, int width, int height);
+
+    // Handle mouse clicks
+    void handle_event(const SDL_Event &e);
+
+    // Draw buttons
+    void draw(SDL_Renderer *renderer, int scale) const;
+
+    int get_selected() const { return selected; }
+};

--- a/inc/SettingsMenu.hpp
+++ b/inc/SettingsMenu.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "AMenu.hpp"
+#include "SettingsSection.hpp"
 
 struct SDL_Window;
 struct SDL_Renderer;
@@ -9,4 +10,10 @@ class SettingsMenu : public AMenu {
 public:
     SettingsMenu();
     static void show(SDL_Window *window, SDL_Renderer *renderer, int width, int height);
+
+private:
+    ButtonAction run(SDL_Window *window, SDL_Renderer *renderer, int width, int height);
+    QualitySection quality;
+    MouseSensitivitySection mouse;
+    ResolutionSection resolution;
 };

--- a/inc/SettingsSection.hpp
+++ b/inc/SettingsSection.hpp
@@ -1,0 +1,51 @@
+#pragma once
+#include <SDL.h>
+#include <string>
+#include "ButtonsCluster.hpp"
+#include "CustomCharacter.hpp"
+
+// Base class for a section in the settings menu
+class SettingsSection {
+protected:
+    std::string label;
+
+public:
+    explicit SettingsSection(const std::string &l) : label(l) {}
+    virtual ~SettingsSection() = default;
+
+    virtual void handle_event(const SDL_Event &e) {}
+
+    // Draw section at given position. Returns bottom y position after drawing.
+    virtual int draw(SDL_Renderer *renderer, int center_x, int y, int width,
+                     int scale) = 0;
+};
+
+// Section with quality buttons
+class QualitySection : public SettingsSection {
+private:
+    ButtonsCluster cluster;
+    int btn_height;
+
+public:
+    QualitySection();
+    int layout(int center_x, int y, int width, int scale);
+    void handle_event(const SDL_Event &e) override { cluster.handle_event(e); }
+    int draw(SDL_Renderer *renderer, int center_x, int y, int width,
+             int scale) override;
+};
+
+// Placeholder for mouse sensitivity slider
+class MouseSensitivitySection : public SettingsSection {
+public:
+    MouseSensitivitySection();
+    int draw(SDL_Renderer *renderer, int center_x, int y, int width,
+             int scale) override;
+};
+
+// Placeholder for resolution slider
+class ResolutionSection : public SettingsSection {
+public:
+    ResolutionSection();
+    int draw(SDL_Renderer *renderer, int center_x, int y, int width,
+             int scale) override;
+};

--- a/src/AMenu.cpp
+++ b/src/AMenu.cpp
@@ -1,4 +1,6 @@
 #include "AMenu.hpp"
+#include "LeaderboardMenu.hpp"
+#include "SettingsMenu.hpp"
 
 AMenu::AMenu(const std::string &t) : title(t) {}
 
@@ -49,8 +51,11 @@ ButtonAction AMenu::run(SDL_Window *window, SDL_Renderer *renderer, int width, i
                 for (auto &btn : buttons) {
                     if (mx >= btn.rect.x && mx < btn.rect.x + btn.rect.w &&
                         my >= btn.rect.y && my < btn.rect.y + btn.rect.h) {
-                        if (btn.action != ButtonAction::Settings &&
-                            btn.action != ButtonAction::Leaderboard) {
+                        if (btn.action == ButtonAction::Settings) {
+                            SettingsMenu::show(window, renderer, width, height);
+                        } else if (btn.action == ButtonAction::Leaderboard) {
+                            LeaderboardMenu::show(window, renderer, width, height);
+                        } else {
                             result = btn.action;
                             running = false;
                         }

--- a/src/ButtonsCluster.cpp
+++ b/src/ButtonsCluster.cpp
@@ -1,0 +1,58 @@
+#include "ButtonsCluster.hpp"
+
+ButtonsCluster::ButtonsCluster(const std::vector<std::string> &names)
+    : selected(0) {
+    for (const auto &n : names) {
+        buttons.emplace_back(n, ButtonAction::None, SDL_Color{255, 255, 255, 255});
+    }
+}
+
+void ButtonsCluster::layout(int x, int y, int width, int height) {
+    if (buttons.empty())
+        return;
+    int gap = 5;
+    int btn_width = (width - gap * static_cast<int>(buttons.size() - 1)) /
+                    static_cast<int>(buttons.size());
+    for (std::size_t i = 0; i < buttons.size(); ++i) {
+        buttons[i].rect = {x + static_cast<int>(i) * (btn_width + gap), y,
+                           btn_width, height};
+    }
+}
+
+void ButtonsCluster::handle_event(const SDL_Event &e) {
+    if (e.type == SDL_MOUSEBUTTONDOWN && e.button.button == SDL_BUTTON_LEFT) {
+        int mx = e.button.x;
+        int my = e.button.y;
+        for (std::size_t i = 0; i < buttons.size(); ++i) {
+            const SDL_Rect &r = buttons[i].rect;
+            if (mx >= r.x && mx < r.x + r.w && my >= r.y && my < r.y + r.h) {
+                selected = static_cast<int>(i);
+                break;
+            }
+        }
+    }
+}
+
+void ButtonsCluster::draw(SDL_Renderer *renderer, int scale) const {
+    SDL_Color white{255, 255, 255, 255};
+    SDL_Color black{0, 0, 0, 255};
+    for (std::size_t i = 0; i < buttons.size(); ++i) {
+        const SDL_Rect &r = buttons[i].rect;
+        bool sel = static_cast<int>(i) == selected;
+        if (sel) {
+            SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
+            SDL_RenderFillRect(renderer, &r);
+            SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
+        } else {
+            SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
+            SDL_RenderFillRect(renderer, &r);
+            SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
+        }
+        SDL_RenderDrawRect(renderer, &r);
+        SDL_Color text_color = sel ? black : white;
+        int text_x = r.x + (r.w - CustomCharacter::text_width(buttons[i].text, scale)) / 2;
+        int text_y = r.y + (r.h - 7 * scale) / 2;
+        CustomCharacter::draw_text(renderer, buttons[i].text, text_x, text_y,
+                                   text_color, scale);
+    }
+}

--- a/src/SettingsMenu.cpp
+++ b/src/SettingsMenu.cpp
@@ -1,10 +1,113 @@
 #include "SettingsMenu.hpp"
+#include <SDL.h>
 
 SettingsMenu::SettingsMenu() : AMenu("SETTINGS") {
+    title_colors.assign(title.size(), SDL_Color{255, 255, 255, 255});
     buttons.push_back(Button{"BACK", ButtonAction::Back, SDL_Color{255, 0, 0, 255}});
+    buttons.push_back(Button{"APPLY", ButtonAction::None, SDL_Color{0, 255, 0, 255}});
 }
 
-void SettingsMenu::show(SDL_Window *window, SDL_Renderer *renderer, int width, int height) {
+ButtonAction SettingsMenu::run(SDL_Window *window, SDL_Renderer *renderer, int width,
+                               int height) {
+    bool running = true;
+    ButtonAction result = ButtonAction::None;
+    SDL_Color white{255, 255, 255, 255};
+
+    while (running) {
+        SDL_GetWindowSize(window, &width, &height);
+        float scale_factor = static_cast<float>(height) / 600.0f;
+        int scale = static_cast<int>(4 * scale_factor);
+        if (scale < 1)
+            scale = 1;
+        int title_scale = scale * 2;
+        int title_height = 7 * title_scale;
+        int title_y = static_cast<int>(40 * scale_factor);
+        int title_x =
+            width / 2 - CustomCharacter::text_width(title, title_scale) / 2;
+
+        int section_width = static_cast<int>(300 * scale_factor);
+        int section_gap = static_cast<int>(40 * scale_factor);
+        int label_height = 7 * scale;
+        int gap = 5 * scale;
+        int placeholder_height = static_cast<int>(20 * scale);
+
+        int quality_y = title_y + title_height + section_gap;
+        int after_quality = quality.layout(width / 2, quality_y, section_width, scale);
+        int mouse_y = after_quality + section_gap;
+        int resolution_y = mouse_y + label_height + gap + placeholder_height + section_gap;
+
+        int button_width = static_cast<int>(140 * scale_factor);
+        int button_height = static_cast<int>(60 * scale_factor);
+        int button_gap = static_cast<int>(20 * scale_factor);
+        int bottom_y = height - button_height - section_gap;
+        buttons[0].rect = {width / 2 - button_width - button_gap / 2, bottom_y,
+                           button_width, button_height};
+        buttons[1].rect = {width / 2 + button_gap / 2, bottom_y, button_width,
+                           button_height};
+
+        SDL_Event event;
+        while (SDL_PollEvent(&event)) {
+            if (event.type == SDL_QUIT) {
+                running = false;
+                result = ButtonAction::Quit;
+            } else if (event.type == SDL_MOUSEBUTTONDOWN &&
+                       event.button.button == SDL_BUTTON_LEFT) {
+                quality.handle_event(event);
+                int mx = event.button.x;
+                int my = event.button.y;
+                for (auto &btn : buttons) {
+                    if (mx >= btn.rect.x && mx < btn.rect.x + btn.rect.w &&
+                        my >= btn.rect.y && my < btn.rect.y + btn.rect.h) {
+                        if (btn.action == ButtonAction::Back) {
+                            result = btn.action;
+                            running = false;
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+
+        SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
+        SDL_RenderClear(renderer);
+
+        // Title
+        CustomCharacter::draw_text(renderer, title, title_x, title_y, white,
+                                   title_scale);
+
+        // Sections
+        quality.draw(renderer, width / 2, quality_y, section_width, scale);
+        mouse.draw(renderer, width / 2, mouse_y, section_width, scale);
+        resolution.draw(renderer, width / 2, resolution_y, section_width, scale);
+
+        // Bottom buttons
+        int mx, my;
+        SDL_GetMouseState(&mx, &my);
+        for (auto &btn : buttons) {
+            bool hover = mx >= btn.rect.x && mx < btn.rect.x + btn.rect.w &&
+                         my >= btn.rect.y && my < btn.rect.y + btn.rect.h;
+            SDL_Color fill = hover ? btn.hover_color : SDL_Color{0, 0, 0, 255};
+            SDL_SetRenderDrawColor(renderer, fill.r, fill.g, fill.b, fill.a);
+            SDL_RenderFillRect(renderer, &btn.rect);
+            SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
+            SDL_RenderDrawRect(renderer, &btn.rect);
+            int text_x = btn.rect.x +
+                         (btn.rect.w - CustomCharacter::text_width(btn.text, scale)) /
+                             2;
+            int text_y = btn.rect.y + (btn.rect.h - 7 * scale) / 2;
+            CustomCharacter::draw_text(renderer, btn.text, text_x, text_y, white,
+                                       scale);
+        }
+
+        SDL_RenderPresent(renderer);
+        SDL_Delay(16);
+    }
+
+    return result;
+}
+
+void SettingsMenu::show(SDL_Window *window, SDL_Renderer *renderer, int width,
+                        int height) {
     SettingsMenu menu;
     menu.run(window, renderer, width, height);
 }

--- a/src/SettingsSection.cpp
+++ b/src/SettingsSection.cpp
@@ -1,0 +1,63 @@
+#include "SettingsSection.hpp"
+
+QualitySection::QualitySection()
+    : SettingsSection("QUALITY"),
+      cluster(std::vector<std::string>{"LOW", "MEDIUM", "HIGH"}),
+      btn_height(20) {}
+
+int QualitySection::layout(int center_x, int y, int width, int scale) {
+    btn_height = static_cast<int>(20 * scale);
+    int label_height = 7 * scale;
+    int gap = 5 * scale;
+    int content_y = y + label_height + gap;
+    cluster.layout(center_x - width / 2, content_y, width, btn_height);
+    return content_y + btn_height;
+}
+
+int QualitySection::draw(SDL_Renderer *renderer, int center_x, int y, int width,
+                         int scale) {
+    int label_w = CustomCharacter::text_width(label, scale);
+    SDL_Color white{255, 255, 255, 255};
+    CustomCharacter::draw_text(renderer, label, center_x - label_w / 2, y, white,
+                               scale);
+    int label_height = 7 * scale;
+    int gap = 5 * scale;
+    int content_y = y + label_height + gap;
+    cluster.draw(renderer, scale);
+    return content_y + btn_height;
+}
+
+MouseSensitivitySection::MouseSensitivitySection()
+    : SettingsSection("MOUSE SENSITIVITY") {}
+
+int MouseSensitivitySection::draw(SDL_Renderer *renderer, int center_x, int y,
+                                  int width, int scale) {
+    int label_w = CustomCharacter::text_width(label, scale);
+    SDL_Color white{255, 255, 255, 255};
+    CustomCharacter::draw_text(renderer, label, center_x - label_w / 2, y, white,
+                               scale);
+    int label_height = 7 * scale;
+    int gap = 5 * scale;
+    SDL_Rect placeholder{center_x - width / 2, y + label_height + gap, width,
+                         static_cast<int>(20 * scale)};
+    SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
+    SDL_RenderDrawRect(renderer, &placeholder);
+    return placeholder.y + placeholder.h;
+}
+
+ResolutionSection::ResolutionSection() : SettingsSection("RESOLUTION") {}
+
+int ResolutionSection::draw(SDL_Renderer *renderer, int center_x, int y, int width,
+                            int scale) {
+    int label_w = CustomCharacter::text_width(label, scale);
+    SDL_Color white{255, 255, 255, 255};
+    CustomCharacter::draw_text(renderer, label, center_x - label_w / 2, y, white,
+                               scale);
+    int label_height = 7 * scale;
+    int gap = 5 * scale;
+    SDL_Rect placeholder{center_x - width / 2, y + label_height + gap, width,
+                         static_cast<int>(20 * scale)};
+    SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
+    SDL_RenderDrawRect(renderer, &placeholder);
+    return placeholder.y + placeholder.h;
+}


### PR DESCRIPTION
## Summary
- Introduce SettingsMenu with quality, mouse sensitivity, and resolution sections
- Add reusable SettingsSection and ButtonsCluster helpers
- Open Settings menu from main or pause menus and keep Back/Apply controls

## Testing
- `cmake -S . -B build`
- `cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_68c2826d9e6c832f9737c85dd0483df5