### PR TITLE
Add leaderboard menu displaying top scores

### DIFF
--- a/inc/AMenu.hpp
+++ b/inc/AMenu.hpp
@@ -12,6 +12,10 @@ protected:
     std::vector<Button> buttons;
     std::vector<SDL_Color> title_colors;
 
+    // Hooks for derived menus to add custom drawings
+    virtual int extra_height(int scale) const { return 0; }
+    virtual void draw_extra(SDL_Renderer *renderer, int width, int y, int scale) {}
+
 public:
     explicit AMenu(const std::string &t);
     virtual ~AMenu() = default;

--- a/inc/LeaderboardMenu.hpp
+++ b/inc/LeaderboardMenu.hpp
@@ -1,12 +1,21 @@
 #pragma once
 #include "AMenu.hpp"
+#include <utility>
+#include <vector>
+#include <string>
 
 struct SDL_Window;
 struct SDL_Renderer;
 
 // Menu showing the leaderboard
 class LeaderboardMenu : public AMenu {
+    std::vector<std::pair<std::string, double>> records;
+
 public:
     LeaderboardMenu();
     static void show(SDL_Window *window, SDL_Renderer *renderer, int width, int height);
+
+protected:
+    int extra_height(int scale) const override;
+    void draw_extra(SDL_Renderer *renderer, int width, int y, int scale) override;
 };

--- a/leaderboard.yaml
+++ b/leaderboard.yaml
@@ -1,0 +1,10 @@
+John Doe: 42.2
+Baba Yaga: 25.9
+John Wick: 24.3
+Jan Kowalski: 21.0
+Ada Lovelace: 18.7
+Linus Torvalds: 15.4
+Grace Hopper: 13.2
+Elon Musk: 10.5
+Marie Curie: 8.8
+Nikola Tesla: 7.1

--- a/src/AMenu.cpp
+++ b/src/AMenu.cpp
@@ -1,4 +1,6 @@
 #include "AMenu.hpp"
+#include "LeaderboardMenu.hpp"
+#include "SettingsMenu.hpp"
 
 AMenu::AMenu(const std::string &t) : title(t) {}
 
@@ -19,10 +21,12 @@ ButtonAction AMenu::run(SDL_Window *window, SDL_Renderer *renderer, int width, i
         int title_scale = scale * 2;
         int title_gap = static_cast<int>(80 * scale_factor);
 
+        int extra_h = extra_height(scale);
         int total_buttons_height = static_cast<int>(buttons.size()) * button_height +
                                    (static_cast<int>(buttons.size()) - 1) * button_gap;
         int title_height = 7 * title_scale;
-        int top_margin = (height - title_height - title_gap - total_buttons_height) / 2;
+        int top_margin =
+            (height - title_height - title_gap - extra_h - total_buttons_height) / 2;
         if (top_margin < 0)
             top_margin = 0;
 
@@ -30,7 +34,8 @@ ButtonAction AMenu::run(SDL_Window *window, SDL_Renderer *renderer, int width, i
         int title_y = top_margin;
 
         int center_x = width / 2 - button_width / 2;
-        int start_y = title_y + title_height + title_gap;
+        int extra_y = title_y + title_height + title_gap;
+        int start_y = extra_y + extra_h;
         for (std::size_t i = 0; i < buttons.size(); ++i) {
             buttons[i].rect = {center_x,
                                start_y + static_cast<int>(i) * (button_height + button_gap),
@@ -49,8 +54,11 @@ ButtonAction AMenu::run(SDL_Window *window, SDL_Renderer *renderer, int width, i
                 for (auto &btn : buttons) {
                     if (mx >= btn.rect.x && mx < btn.rect.x + btn.rect.w &&
                         my >= btn.rect.y && my < btn.rect.y + btn.rect.h) {
-                        if (btn.action != ButtonAction::Settings &&
-                            btn.action != ButtonAction::Leaderboard) {
+                        if (btn.action == ButtonAction::Settings) {
+                            SettingsMenu::show(window, renderer, width, height);
+                        } else if (btn.action == ButtonAction::Leaderboard) {
+                            LeaderboardMenu::show(window, renderer, width, height);
+                        } else {
                             result = btn.action;
                             running = false;
                         }
@@ -85,6 +93,8 @@ ButtonAction AMenu::run(SDL_Window *window, SDL_Renderer *renderer, int width, i
             CustomCharacter::draw_character(renderer, title[i], tx, title_y, c, title_scale);
             tx += (5 + 1) * title_scale;
         }
+
+        draw_extra(renderer, width, extra_y, scale);
 
         for (auto &btn : buttons) {
             bool hover = mx >= btn.rect.x && mx < btn.rect.x + btn.rect.w &&

--- a/src/LeaderboardMenu.cpp
+++ b/src/LeaderboardMenu.cpp
@@ -1,10 +1,88 @@
 #include "LeaderboardMenu.hpp"
+#include <algorithm>
+#include <fstream>
+#include <sstream>
+#include <iomanip>
+
+// Trim helper
+static std::string trim(const std::string &s) {
+    std::size_t start = s.find_first_not_of(" \t");
+    std::size_t end = s.find_last_not_of(" \t");
+    if (start == std::string::npos || end == std::string::npos)
+        return "";
+    return s.substr(start, end - start + 1);
+}
 
 LeaderboardMenu::LeaderboardMenu() : AMenu("LEADERBOARD") {
+    title_colors.assign(title.size(), SDL_Color{255, 255, 255, 255});
+
+    std::ifstream file("leaderboard.yaml");
+    std::string line;
+    while (std::getline(file, line) && records.size() < 10) {
+        std::size_t pos = line.find(':');
+        if (pos == std::string::npos)
+            continue;
+        std::string name = trim(line.substr(0, pos));
+        std::string val = trim(line.substr(pos + 1));
+        std::istringstream ss(val);
+        double score = 0.0;
+        ss >> score;
+        records.push_back({name, score});
+    }
+    std::sort(records.begin(), records.end(),
+              [](const auto &a, const auto &b) { return a.second > b.second; });
+
     buttons.push_back(Button{"BACK", ButtonAction::Back, SDL_Color{255, 0, 0, 255}});
+}
+
+int LeaderboardMenu::extra_height(int scale) const {
+    int line_height = 7 * scale;
+    int gap = scale;
+    if (records.empty())
+        return 0;
+    return static_cast<int>(records.size()) * line_height +
+           (static_cast<int>(records.size()) - 1) * gap;
+}
+
+void LeaderboardMenu::draw_extra(SDL_Renderer *renderer, int width, int y, int scale) {
+    SDL_Color number_colors[3] = {
+        {255, 215, 0, 255},   // gold
+        {192, 192, 192, 255}, // silver
+        {205, 127, 50, 255}   // bronze
+    };
+    int line_height = 7 * scale;
+    int gap = scale;
+    for (std::size_t i = 0; i < records.size(); ++i) {
+        SDL_Color num_color = {255, 255, 255, 255};
+        if (i < 3)
+            num_color = number_colors[i];
+
+        std::string number = std::to_string(i + 1) + ".";
+        std::string name = records[i].first;
+        std::ostringstream os;
+        os << std::fixed << std::setprecision(1) << records[i].second;
+        std::string score = os.str();
+
+        int number_width = CustomCharacter::text_width(number, scale);
+        int name_width = CustomCharacter::text_width(name, scale);
+        int score_width = CustomCharacter::text_width(score, scale);
+        int gap1 = scale;
+        int gap2 = 4 * scale;
+        int total_width = number_width + gap1 + name_width + gap2 + score_width;
+        int x = width / 2 - total_width / 2;
+
+        CustomCharacter::draw_text(renderer, number, x, y, num_color, scale);
+        x += number_width + gap1;
+        CustomCharacter::draw_text(renderer, name, x, y, SDL_Color{255, 255, 255, 255}, scale);
+        x += name_width + gap2;
+        CustomCharacter::draw_text(renderer, score, x, y, SDL_Color{255, 255, 255, 255}, scale);
+
+        y += line_height + gap;
+    }
 }
 
 void LeaderboardMenu::show(SDL_Window *window, SDL_Renderer *renderer, int width, int height) {
     LeaderboardMenu menu;
     menu.run(window, renderer, width, height);
 }
+


### PR DESCRIPTION
## Summary
- extend base menu with hooks for custom rendering and submenu handling
- implement leaderboard menu that loads scores from YAML and highlights top three
- provide sample `leaderboard.yaml` data

## Testing
- ⚠️ `cmake -S . -B build` *(missing SDL2)*

------
https://chatgpt.com/codex/tasks/task_e_68c2fa4b7f2c832fa4e99c1cb8d66e51