### PR TITLE
Fix pause menu crash after resizing

### DIFF
--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -378,7 +378,10 @@ void Renderer::process_events(RenderState &st, SDL_Window *win, SDL_Renderer *re
                         SDL_ShowCursor(SDL_ENABLE);
                         SDL_SetWindowGrab(win, SDL_FALSE);
                         SDL_WarpMouseInWindow(win, W / 2, H / 2);
-                        bool resume = PauseMenu::show(win, ren, W, H);
+                        int current_w = W;
+                        int current_h = H;
+                        SDL_GetWindowSize(win, &current_w, &current_h);
+                        bool resume = PauseMenu::show(win, ren, current_w, current_h);
                         if (resume)
                         {
                                 st.focused = true;


### PR DESCRIPTION
## Summary
- Fix segmentation fault after changing resolution by passing current window dimensions to pause menu.

## Testing
- `cmake -S . -B build`
- `cmake --build build -j`


------
https://chatgpt.com/codex/tasks/task_e_68c4a924c4cc832f8fe4f8d7fbfdd3cf