### PR TITLE
Support beams without laser via optional argument

### DIFF
--- a/inc/Beam.hpp
+++ b/inc/Beam.hpp
@@ -12,5 +12,5 @@ class Beam
        std::shared_ptr<BeamSource> source;
        Beam(const Vec3 &origin, const Vec3 &dir, double ray_radius,
                 double length, double intensity, int base_oid, int laser_mat,
-                int big_mat, int mid_mat, int small_mat);
+                int big_mat, int mid_mat, int small_mat, bool with_laser);
 };

--- a/inc/BeamSource.hpp
+++ b/inc/BeamSource.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "Laser.hpp"
+#include "LightRay.hpp"
 #include "Sphere.hpp"
 #include <memory>
 
@@ -9,9 +10,12 @@ class BeamSource : public Sphere
 	Sphere mid;
 	Sphere inner;
        std::shared_ptr<Laser> beam;
+       std::shared_ptr<LightRay> light;
        BeamSource(const Vec3 &c, const Vec3 &dir,
-                          const std::shared_ptr<Laser> &bm, double mid_radius,
-                          int oid, int mat_big, int mat_mid, int mat_small);
+                          const std::shared_ptr<Laser> &bm,
+                          const std::shared_ptr<LightRay> &lt,
+                          double mid_radius, int oid, int mat_big,
+                          int mat_mid, int mat_small);
 	bool hit(const Ray &r, double tmin, double tmax,
 			 HitRecord &rec) const override;
 	bool bounding_box(AABB &out) const override

--- a/src/Beam.cpp
+++ b/src/Beam.cpp
@@ -2,13 +2,22 @@
 
 Beam::Beam(const Vec3 &origin, const Vec3 &dir, double ray_radius,
                   double length, double intensity, int base_oid, int laser_mat,
-                  int big_mat, int mid_mat, int small_mat)
+                  int big_mat, int mid_mat, int small_mat, bool with_laser)
 {
        light = std::make_shared<LightRay>(origin, dir, ray_radius, intensity);
-       laser = std::make_shared<Laser>(origin, dir, length, intensity, base_oid,
-                                                                       laser_mat);
-       source = std::make_shared<BeamSource>(
-               origin, dir, laser, ray_radius, base_oid + 1, big_mat, mid_mat,
-               small_mat);
-       laser->source = source;
+       if (with_laser)
+       {
+               laser = std::make_shared<Laser>(origin, dir, length, intensity,
+                                                                               base_oid, laser_mat);
+               source = std::make_shared<BeamSource>(origin, dir, laser, light,
+                                                                                ray_radius, base_oid + 1,
+                                                                                big_mat, mid_mat, small_mat);
+               laser->source = source;
+       }
+       else
+       {
+               source = std::make_shared<BeamSource>(origin, dir, nullptr, light,
+                                                                                ray_radius, base_oid, big_mat,
+                                                                                mid_mat, small_mat);
+       }
 }


### PR DESCRIPTION
## Summary
- Allow beam definitions to specify an optional `L`/`NL` flag to toggle laser creation
- Track `LightRay` within `BeamSource` so sources still translate/rotate when laser is absent
- Parse beam lines to build scenes with or without lasers and adjust lights accordingly

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68c7bdbcca9c832fa10c0e7963754869