### PR TITLE
Implement light ray scoring system

### DIFF
--- a/inc/Scene.hpp
+++ b/inc/Scene.hpp
@@ -24,11 +24,14 @@ class Scene
         // Update goal-scored effects on beam targets.
         void update_goal_targets(double dt, std::vector<Material> &materials);
 
-	// Build bounding volume hierarchy for static geometry.
-	void build_bvh();
+        // Build bounding volume hierarchy for static geometry.
+        void build_bvh();
 
-	// Test a ray against all objects.
-	bool hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const;
+        // Test a ray against all objects.
+        bool hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const;
+
+        // Compute total score contributed by beam lights.
+        double compute_score(const std::vector<Material> &materials) const;
 
 	// Determine whether object at index collides with others.
 	bool collides(int index) const;

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -19,7 +19,9 @@
 #include <cstring>
 #include <fstream>
 #include <iostream>
+#include <iomanip>
 #include <random>
+#include <sstream>
 #include <string>
 #include <thread>
 
@@ -713,6 +715,16 @@ void Renderer::render_frame(RenderState &st, SDL_Renderer *ren, SDL_Texture *tex
         SDL_SetRenderDrawColor(ren, 255, 255, 255, 255);
         SDL_RenderClear(ren);
         SDL_RenderCopy(ren, tex, nullptr, nullptr);
+        double score = scene.compute_score(mats);
+        std::ostringstream score_stream;
+        score_stream << "SCORE: " << std::fixed << std::setprecision(5) << score;
+        std::string score_text = score_stream.str();
+        SDL_Color white{255, 255, 255, 255};
+        const int score_scale = 2;
+        const int score_x = 5;
+        const int score_y = 5;
+        CustomCharacter::draw_text(ren, score_text, score_x, score_y, white, score_scale);
+        const int score_height = 7 * score_scale;
         if (st.edit_mode && g_developer_mode)
         {
                 auto project = [&](const Vec3 &p, int &sx, int &sy) -> bool
@@ -789,9 +801,10 @@ void Renderer::render_frame(RenderState &st, SDL_Renderer *ren, SDL_Texture *tex
                 const char *legend[] = {"1-PLANE",  "2-SPHERE",   "3-CUBE",
                                          "4-CONE",  "5-CYLINDER", "SCROLL-SIZE",
                                          "MCLICK-DEL"};
+                int legend_base_y = score_y + score_height + 5;
                 for (int i = 0; i < 7; ++i)
                         CustomCharacter::draw_text(ren, legend[i], 5,
-                                                    5 + i * (7 * scale + 2), red, scale);
+                                                    legend_base_y + i * (7 * scale + 2), red, scale);
                 std::string text = "DEVELOPER MODE";
                 int tw = CustomCharacter::text_width(text, scale);
                 CustomCharacter::draw_text(ren, text, W - tw - 5, 5, red, scale);


### PR DESCRIPTION
## Summary
- add a scoring calculation that estimates illuminated area from beam light rays and ignores transparent blockers
- render the formatted score in the top-left corner while shifting developer overlays to avoid overlap

## Testing
- cmake -S . -B build *(fails: missing SDL2 package in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc29c6a2a8832f9bf06baca2c80a40