### PR TITLE
Implement beam scoring and HUD display

### DIFF
--- a/inc/LightRay.hpp
+++ b/inc/LightRay.hpp
@@ -5,13 +5,14 @@ class LightRay
 {
         public:
         Ray ray;
-       double radius;
-       double intensity;
-       Vec3 color;
-       LightRay(const Vec3 &origin, const Vec3 &dir, double r, double intens,
-                               const Vec3 &col)
-               : ray(origin, dir.normalized()), radius(r), intensity(intens),
-                 color(col)
-       {
-       }
+        double radius;
+        double intensity;
+        Vec3 color;
+        double length;
+        LightRay(const Vec3 &origin, const Vec3 &dir, double r, double intens,
+                          const Vec3 &col, double len)
+                : ray(origin, dir.normalized()), radius(r), intensity(intens),
+                  color(col), length(len)
+        {
+        }
 };

--- a/inc/Scene.hpp
+++ b/inc/Scene.hpp
@@ -24,14 +24,17 @@ class Scene
         // Update goal-scored effects on beam targets.
         void update_goal_targets(double dt, std::vector<Material> &materials);
 
-	// Build bounding volume hierarchy for static geometry.
-	void build_bvh();
+        // Build bounding volume hierarchy for static geometry.
+        void build_bvh();
 
-	// Test a ray against all objects.
-	bool hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const;
+        // Test a ray against all objects.
+        bool hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const;
 
-	// Determine whether object at index collides with others.
-	bool collides(int index) const;
+        // Compute illuminated surface score for active beams.
+        double compute_score() const;
+
+        // Determine whether object at index collides with others.
+        bool collides(int index) const;
 
 	// Move object while preventing collisions.
 	Vec3 move_with_collision(int index, const Vec3 &delta);
@@ -50,4 +53,16 @@ class Scene
                                                std::unordered_map<int, int> &id_map);
         void remap_light_ids(const std::unordered_map<int, int> &id_map);
         void reflect_lights(const std::vector<Material> &mats);
+        struct IlluminationSegment
+        {
+                Vec3 origin;
+                Vec3 dir;
+                double radius;
+                double length;
+                int source_id;
+        };
+        void collect_illumination_segments(
+                std::vector<IlluminationSegment> &segments) const;
+        bool score_intersection(const Ray &ray, double max_dist, int source_id,
+                                                        HitRecord &rec, HittablePtr &hit_obj) const;
 };

--- a/src/Beam.cpp
+++ b/src/Beam.cpp
@@ -5,7 +5,8 @@ Beam::Beam(const Vec3 &origin, const Vec3 &dir, double ray_radius,
                   int big_mat, int mid_mat, int small_mat, bool with_laser,
                   const Vec3 &color)
 {
-       light = std::make_shared<LightRay>(origin, dir, ray_radius, intensity, color);
+       light = std::make_shared<LightRay>(origin, dir, ray_radius, intensity,
+                                                                                color, length);
        if (with_laser)
        {
                laser = std::make_shared<Laser>(origin, dir, length, intensity,

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -187,6 +187,7 @@ struct Renderer::RenderState
         Vec3 edit_pos;
         int spawn_key = -1;
         double fps = 0.0;
+        double score = 0.0;
 };
 
 /// Initialize SDL window, renderer and texture objects.
@@ -775,6 +776,16 @@ void Renderer::render_frame(RenderState &st, SDL_Renderer *ren, SDL_Texture *tex
                                                                                   pts[e[1]].x, pts[e[1]].y);
                 }
         }
+        const int score_scale = 2;
+        const int score_y = 5;
+        const int score_x = 5;
+        const int score_height = 7 * score_scale;
+        int legend_offset_y = score_y + score_height + 10;
+        SDL_Color white{255, 255, 255, 255};
+        char score_buf[64];
+        std::snprintf(score_buf, sizeof(score_buf), "SCORE: %.5f", st.score);
+        std::string score_text(score_buf);
+        CustomCharacter::draw_text(ren, score_text, score_x, score_y, white, score_scale);
         // Draw crosshair at the center of the screen
         SDL_SetRenderDrawColor(ren, 255, 255, 255, 255);
         int cx = W / 2;
@@ -791,7 +802,8 @@ void Renderer::render_frame(RenderState &st, SDL_Renderer *ren, SDL_Texture *tex
                                          "MCLICK-DEL"};
                 for (int i = 0; i < 7; ++i)
                         CustomCharacter::draw_text(ren, legend[i], 5,
-                                                    5 + i * (7 * scale + 2), red, scale);
+                                                    legend_offset_y + i * (7 * scale + 2),
+                                                    red, scale);
                 std::string text = "DEVELOPER MODE";
                 int tw = CustomCharacter::text_width(text, scale);
                 CustomCharacter::draw_text(ren, text, W - tw - 5, 5, red, scale);
@@ -971,6 +983,7 @@ void Renderer::render_window(std::vector<Material> &mats,
                 handle_keyboard(st, dt, mats);
                 scene.update_goal_targets(dt, mats);
                 update_selection(st, mats);
+                st.score = scene.compute_score();
                 render_frame(st, ren, tex, framebuffer, pixels, RW, RH, W, H, T,
                                          mats);
         }


### PR DESCRIPTION
## Summary
- extend LightRay and scene helpers to track beam segment lengths for scoring
- add Scene::compute_score that samples beam cross-sections and accumulates illuminated surface area while skipping non-scorable geometry
- surface the live score in the renderer HUD and offset the developer legend beneath it

## Testing
- `cmake -S . -B build` *(fails: SDL2 development files are unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc4060c1a4832f91b683a6023f901c