### PR TITLE
Add spotlight scoring and HUD display

### DIFF
--- a/inc/material.hpp
+++ b/inc/material.hpp
@@ -12,11 +12,12 @@ class Material
 	Vec3 color;		 // current color used for rendering
 	Vec3 base_color; // original color stored for edits
 	double alpha = 1.0;
-	double specular_exp = 50.0;
-	double specular_k = 0.5;
-	bool mirror = false;
-	bool random_alpha = false;
-	bool checkered = false; // render as checkered pattern when true
+        double specular_exp = 50.0;
+        double specular_k = 0.5;
+        bool mirror = false;
+        bool random_alpha = false;
+        bool checkered = false; // render as checkered pattern when true
+        bool scorable = false;
 };
 
 Vec3 phong(const Material &m, const Ambient &ambient,

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -494,6 +494,7 @@ bool process_plane(const TableData &table, Scene &scene, int &oid, int &mid,
         plane->movable = movable;
         plane->scorable = scorable;
         materials.push_back(make_material(rgb, reflective, transparent));
+        materials.back().scorable = scorable;
         scene.objects.push_back(plane);
         ++mid;
         return true;
@@ -543,6 +544,7 @@ bool process_sphere(const TableData &table, Scene &scene, int &oid, int &mid,
         sphere->movable = movable;
         sphere->scorable = scorable;
         materials.push_back(make_material(rgb, reflective, transparent));
+        materials.back().scorable = scorable;
         scene.objects.push_back(sphere);
         ++mid;
         return true;
@@ -601,6 +603,7 @@ bool process_cube(const TableData &table, Scene &scene, int &oid, int &mid,
         cube->movable = movable;
         cube->scorable = scorable;
         materials.push_back(make_material(rgb, reflective, transparent));
+        materials.back().scorable = scorable;
         scene.objects.push_back(cube);
         ++mid;
         return true;
@@ -656,6 +659,7 @@ bool process_cylinder(const TableData &table, Scene &scene, int &oid, int &mid,
         cylinder->movable = movable;
         cylinder->scorable = scorable;
         materials.push_back(make_material(rgb, reflective, transparent));
+        materials.back().scorable = scorable;
         scene.objects.push_back(cylinder);
         ++mid;
         return true;
@@ -711,6 +715,7 @@ bool process_cone(const TableData &table, Scene &scene, int &oid, int &mid,
         cone->movable = movable;
         cone->scorable = scorable;
         materials.push_back(make_material(rgb, reflective, transparent));
+        materials.back().scorable = scorable;
         scene.objects.push_back(cone);
         ++mid;
         return true;
@@ -781,18 +786,21 @@ bool process_beam_source(const TableData &table, Scene &scene, int &oid, int &mi
         materials.back().color = Vec3(1.0, 1.0, 1.0);
         materials.back().base_color = materials.back().color;
         materials.back().alpha = 0.67;
+        materials.back().scorable = scorable_flag;
         int big_mat = mid++;
 
         materials.emplace_back();
         materials.back().color = (Vec3(1.0, 1.0, 1.0) + color_unit) * 0.5;
         materials.back().base_color = materials.back().color;
         materials.back().alpha = 0.33;
+        materials.back().scorable = scorable_flag;
         int mid_mat = mid++;
 
         materials.emplace_back();
         materials.back().color = color_unit;
         materials.back().base_color = color_unit;
         materials.back().alpha = 1.0;
+        materials.back().scorable = scorable_flag;
         int small_mat = mid++;
 
         auto beam = std::make_shared<Beam>(position, dir_norm, beam_radius, length, intensity,
@@ -863,18 +871,21 @@ bool process_beam_target(const TableData &table, Scene &scene, int &oid, int &mi
         materials.back().color = Vec3(0.0, 0.0, 0.0);
         materials.back().base_color = materials.back().color;
         materials.back().alpha = 0.33;
+        materials.back().scorable = scorable;
         int big_mat = mid++;
 
         materials.emplace_back();
         materials.back().color = color_unit * 0.5;
         materials.back().base_color = materials.back().color;
         materials.back().alpha = 0.67;
+        materials.back().scorable = scorable;
         int mid_mat = mid++;
 
         materials.emplace_back();
         materials.back().color = color_unit;
         materials.back().base_color = color_unit;
         materials.back().alpha = 1.0;
+        materials.back().scorable = scorable;
         int small_mat = mid++;
 
         auto target = std::make_shared<BeamTarget>(position, radius, oid++, big_mat, mid_mat, small_mat);


### PR DESCRIPTION
## Summary
- add scoring context that counts spotlight-lit surface area per light/material pair
- mark parser-generated materials as scorable to participate in scoring calculations
- render the current score in the HUD and adjust the developer legend layout

## Testing
- cmake -S . -B build *(fails: missing SDL2 package)*

------
https://chatgpt.com/codex/tasks/task_e_68cd48c07264832fb976af031db299a1