### PR TITLE
Add automatic scene persistence in developer mode

### DIFF
--- a/inc/Renderer.hpp
+++ b/inc/Renderer.hpp
@@ -28,6 +28,7 @@ class Renderer
                                            const std::string &scene_path);
         private:
         struct RenderState;
+        void mark_scene_dirty(RenderState &st);
         bool init_sdl(SDL_Window *&win, SDL_Renderer *&ren, SDL_Texture *&tex,
                                        int W, int H, int RW, int RH);
         void process_events(RenderState &st, SDL_Window *win, SDL_Renderer *ren,


### PR DESCRIPTION
## Summary
- track when developer interactions modify the loaded scene and auto-save updates to the level TOML file
- add a renderer helper for marking dirty state and throttle repeated saves to avoid excessive disk writes
- allow reloading the scene from disk with the R key while in developer mode, resetting edit state on success

## Testing
- `cmake -S . -B build` *(fails: missing SDL2 configuration files in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd4ad5c244832f8da2cd88354b003c