### PR TITLE
Add visual cone indicator for beam sources

### DIFF
--- a/inc/BeamSource.hpp
+++ b/inc/BeamSource.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "Cone.hpp"
 #include "Laser.hpp"
 #include "LightRay.hpp"
 #include "Sphere.hpp"
@@ -6,25 +7,27 @@
 
 class BeamSource : public Sphere
 {
-	public:
-	Sphere mid;
-	Sphere inner;
-       std::shared_ptr<Laser> beam;
-       std::shared_ptr<LightRay> light;
-       BeamSource(const Vec3 &c, const Vec3 &dir,
+        public:
+        Sphere mid;
+        Sphere inner;
+        Cone orientation;
+        std::shared_ptr<Laser> beam;
+        std::shared_ptr<LightRay> light;
+        BeamSource(const Vec3 &c, const Vec3 &dir,
                           const std::shared_ptr<Laser> &bm,
                           const std::shared_ptr<LightRay> &lt,
                           double mid_radius, int oid, int mat_big,
                           int mat_mid, int mat_small);
 	bool hit(const Ray &r, double tmin, double tmax,
 			 HitRecord &rec) const override;
-	bool bounding_box(AABB &out) const override
-	{
-		return Sphere::bounding_box(out);
-	}
+        bool bounding_box(AABB &out) const override;
         void translate(const Vec3 &delta) override;
         void rotate(const Vec3 &axis, double angle) override;
         Vec3 spot_direction() const override;
         bool blocks_when_transparent() const override { return true; }
         bool casts_shadow() const override { return false; }
+
+        private:
+        void update_orientation_geometry(const Vec3 &dir);
+        double spotlight_radius() const;
 };

--- a/inc/Cone.hpp
+++ b/inc/Cone.hpp
@@ -5,15 +5,17 @@
 class Cone : public Hittable
 {
 	public:
-	Vec3 center;
-	Vec3 axis;
-	double radius;
-	double height;
-	Cone(const Vec3 &c, const Vec3 &ax, double r, double h, int oid, int mid);
+        Vec3 center;
+        Vec3 axis;
+        double radius;
+        double height;
+        bool has_base;
+        Cone(const Vec3 &c, const Vec3 &ax, double r, double h, int oid, int mid,
+                 bool with_base = true);
 
-	bool hit(const Ray &r, double tmin, double tmax,
-			 HitRecord &rec) const override;
-	bool bounding_box(AABB &out) const override;
+        bool hit(const Ray &r, double tmin, double tmax,
+                         HitRecord &rec) const override;
+        bool bounding_box(AABB &out) const override;
 	void translate(const Vec3 &delta) override { center += delta; }
 	void rotate(const Vec3 &axis, double angle) override;
 	ShapeType shape_type() const override { return ShapeType::Cone; }

--- a/src/BeamSource.cpp
+++ b/src/BeamSource.cpp
@@ -1,5 +1,19 @@
 #include "BeamSource.hpp"
+#include <algorithm>
 #include <cmath>
+
+namespace
+{
+constexpr double kSpotlightLaserRatio = 20.0;
+constexpr double kDirectionEps = 1e-12;
+
+Vec3 normalized_or_default(const Vec3 &dir)
+{
+        if (dir.length_squared() < kDirectionEps)
+                return Vec3(0, 0, 1);
+        return dir.normalized();
+}
+}
 
 BeamSource::BeamSource(const Vec3 &c, const Vec3 &dir,
                                            const std::shared_ptr<Laser> &bm,
@@ -8,60 +22,68 @@ BeamSource::BeamSource(const Vec3 &c, const Vec3 &dir,
                                            int mat_mid, int mat_small)
        : Sphere(c, mid_radius * 2.0, oid, mat_big),
          mid(c, mid_radius * 1.5, -oid - 1, mat_mid),
-         inner(c, mid_radius, -oid - 2, mat_small), beam(bm), light(lt)
+         inner(c, mid_radius, -oid - 2, mat_small),
+         orientation(c, Vec3(0, 0, -1), 1.0, 1.0, -oid - 3, mat_small, false),
+         beam(bm), light(lt)
 {
-        (void)dir;
+        update_orientation_geometry(dir);
 }
 
 bool BeamSource::hit(const Ray &r, double tmin, double tmax,
-					 HitRecord &rec) const
+                                         HitRecord &rec) const
 {
-	bool hit_any = false;
-	HitRecord tmp;
-	double closest = tmax;
-	if (Sphere::hit(r, tmin, closest, tmp))
-	{
-		hit_any = true;
-		closest = tmp.t;
-		rec = tmp;
+        bool hit_any = false;
+        HitRecord tmp;
+        double closest = tmax;
+        Vec3 beam_dir = normalized_or_default(spot_direction());
+        if (Sphere::hit(r, tmin, closest, tmp))
+        {
+                hit_any = true;
+                closest = tmp.t;
+                rec = tmp;
 	}
 	if (mid.hit(r, tmin, closest, tmp))
 	{
 		hit_any = true;
 		closest = tmp.t;
 		rec = tmp;
-	}
+        }
         if (inner.hit(r, tmin, closest, tmp))
         {
-                Vec3 beam_dir = beam
-                                        ? beam->path.dir
-                                        : (light ? light->ray.dir : Vec3(0, 0, 1));
                 Vec3 to_hit = (tmp.p - inner.center).normalized();
-		const double hole_cos = std::sqrt(1.0 - 0.25 * 0.25);
-		if (Vec3::dot(beam_dir, to_hit) < hole_cos)
-		{
-			hit_any = true;
-			closest = tmp.t;
-			rec = tmp;
-		}
-	}
-	return hit_any;
+                const double hole_cos = std::sqrt(1.0 - 0.25 * 0.25);
+                if (Vec3::dot(beam_dir, to_hit) < hole_cos)
+                {
+                        hit_any = true;
+                        closest = tmp.t;
+                        rec = tmp;
+                }
+        }
+        if (orientation.hit(r, tmin, closest, tmp))
+        {
+                hit_any = true;
+                closest = tmp.t;
+                rec = tmp;
+        }
+        return hit_any;
 }
 
 void BeamSource::translate(const Vec3 &delta)
 {
-	Sphere::translate(delta);
-	mid.translate(delta);
-	inner.translate(delta);
+        Sphere::translate(delta);
+        mid.translate(delta);
+        inner.translate(delta);
+        orientation.translate(delta);
         if (beam)
                 beam->path.orig += delta;
         if (light)
                 light->ray.orig += delta;
+        update_orientation_geometry(spot_direction());
 }
 
 void BeamSource::rotate(const Vec3 &ax, double angle)
 {
-	auto rotate_vec = [](const Vec3 &v, const Vec3 &axis, double ang)
+        auto rotate_vec = [](const Vec3 &v, const Vec3 &axis, double ang)
 	{
 		double c = std::cos(ang);
 		double s = std::sin(ang);
@@ -73,6 +95,7 @@ void BeamSource::rotate(const Vec3 &ax, double angle)
         if (light)
                 light->ray.dir =
                         rotate_vec(light->ray.dir, ax, angle).normalized();
+        update_orientation_geometry(spot_direction());
 }
 
 Vec3 BeamSource::spot_direction() const
@@ -82,4 +105,58 @@ Vec3 BeamSource::spot_direction() const
         if (light)
                 return light->ray.dir;
         return Vec3(0, 0, 1);
+}
+
+double BeamSource::spotlight_radius() const
+{
+        double base_radius = inner.radius;
+        if (beam)
+                base_radius = beam->radius;
+        else if (light)
+                base_radius = light->radius;
+        else if (radius > 0.0)
+                base_radius = radius * 0.5;
+        base_radius = std::max(base_radius, 0.0);
+        return base_radius * kSpotlightLaserRatio;
+}
+
+void BeamSource::update_orientation_geometry(const Vec3 &dir)
+{
+        Vec3 direction = dir;
+        if (direction.length_squared() < kDirectionEps)
+        {
+                Vec3 fallback = spot_direction();
+                if (fallback.length_squared() < kDirectionEps)
+                        fallback = Vec3(0, 0, 1);
+                direction = fallback;
+        }
+        direction = normalized_or_default(direction);
+
+        double height = radius;
+        if (height <= 0.0)
+                height = 1e-4;
+
+        double base_radius = spotlight_radius();
+
+        orientation.height = height;
+        orientation.radius = base_radius;
+        Vec3 axis = (-direction);
+        if (axis.length_squared() < kDirectionEps)
+                axis = Vec3(0, 0, -1);
+        orientation.axis = axis.normalized();
+        orientation.center = center + direction * (height * 0.5);
+}
+
+bool BeamSource::bounding_box(AABB &out) const
+{
+        if (!Sphere::bounding_box(out))
+                return false;
+        AABB tmp;
+        if (mid.bounding_box(tmp))
+                out = AABB::surrounding_box(out, tmp);
+        if (inner.bounding_box(tmp))
+                out = AABB::surrounding_box(out, tmp);
+        if (orientation.bounding_box(tmp))
+                out = AABB::surrounding_box(out, tmp);
+        return true;
 }

--- a/src/Cone.cpp
+++ b/src/Cone.cpp
@@ -1,11 +1,12 @@
 #include "Cone.hpp"
 #include <cmath>
 
-Cone::Cone(const Vec3 &c, const Vec3 &ax, double r, double h, int oid, int mid)
-	: center(c), axis(ax.normalized()), radius(r), height(h)
+Cone::Cone(const Vec3 &c, const Vec3 &ax, double r, double h, int oid, int mid,
+                   bool with_base)
+        : center(c), axis(ax.normalized()), radius(r), height(h), has_base(with_base)
 {
-	object_id = oid;
-	material_id = mid;
+        object_id = oid;
+        material_id = mid;
 }
 
 bool Cone::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
@@ -59,28 +60,31 @@ bool Cone::hit(const Ray &r, double tmin, double tmax, HitRecord &rec) const
 		}
 	}
 
-	Vec3 base_center = center - axis * (height * 0.5);
-	double denom = Vec3::dot(r.dir, (-1) * axis);
-	if (std::fabs(denom) > 1e-9)
-	{
-		double t = Vec3::dot(base_center - r.orig, (-1) * axis) / denom;
-		if (t >= tmin && t <= closest)
-		{
-			Vec3 p = r.at(t);
-			if ((p - base_center).length_squared() <= radius * radius)
-			{
-				rec.t = t;
-				rec.p = p;
-				rec.object_id = object_id;
-				rec.material_id = material_id;
-				rec.set_face_normal(r, (-1) * axis);
-				closest = t;
-				hit_any = true;
-			}
-		}
-	}
+        if (has_base)
+        {
+                Vec3 base_center = center - axis * (height * 0.5);
+                double denom = Vec3::dot(r.dir, (-1) * axis);
+                if (std::fabs(denom) > 1e-9)
+                {
+                        double t = Vec3::dot(base_center - r.orig, (-1) * axis) / denom;
+                        if (t >= tmin && t <= closest)
+                        {
+                                Vec3 p = r.at(t);
+                                if ((p - base_center).length_squared() <= radius * radius)
+                                {
+                                        rec.t = t;
+                                        rec.p = p;
+                                        rec.object_id = object_id;
+                                        rec.material_id = material_id;
+                                        rec.set_face_normal(r, (-1) * axis);
+                                        closest = t;
+                                        hit_any = true;
+                                }
+                        }
+                }
+        }
 
-	return hit_any;
+        return hit_any;
 }
 
 bool Cone::bounding_box(AABB &out) const

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -804,6 +804,7 @@ bool process_beam_source(const TableData &table, Scene &scene, int &oid, int &mi
         beam->source->scorable = scorable_flag;
         beam->source->mid.scorable = scorable_flag;
         beam->source->inner.scorable = scorable_flag;
+        beam->source->orientation.scorable = scorable_flag;
         if (beam->laser)
                 beam->laser->scorable = scorable_flag;
         const double cone_cos = std::sqrt(1.0 - 0.25 * 0.25);


### PR DESCRIPTION
## Summary
- embed a capless cone inside BeamSource to visualize the beam orientation and keep transforms/bounds in sync
- add optional base support to Cone so it can represent the open indicator geometry
- propagate the scorable flag to the new orientation piece for consistency

## Testing
- `cmake -S . -B build` *(fails: missing SDL2 package in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce5200c484832f8deabaca8547f0ba