### PR TITLE
Add level completion HUD indicator and menu

### DIFF
--- a/inc/LevelFinishedMenu.hpp
+++ b/inc/LevelFinishedMenu.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "AMenu.hpp"
+
+class LevelFinishedMenu : public AMenu {
+public:
+    LevelFinishedMenu();
+    static ButtonAction show(SDL_Window *window, SDL_Renderer *renderer, int width, int height,
+                             bool transparent = true);
+};

--- a/src/LevelFinishedMenu.cpp
+++ b/src/LevelFinishedMenu.cpp
@@ -1,0 +1,16 @@
+#include "LevelFinishedMenu.hpp"
+
+LevelFinishedMenu::LevelFinishedMenu() : AMenu("LEVEL FINISHED") {
+    title_colors.assign(title.size(), SDL_Color{255, 255, 255, 255});
+    buttons.push_back(Button{"CONTINUE", ButtonAction::Resume, SDL_Color{96, 255, 128, 255}});
+    buttons.push_back(
+        Button{"LEADERBOARD", ButtonAction::Leaderboard, SDL_Color{96, 128, 255, 255}});
+    buttons.push_back(Button{"SETTINGS", ButtonAction::Settings, SDL_Color{255, 220, 96, 255}});
+    buttons.push_back(Button{"QUIT", ButtonAction::Quit, SDL_Color{255, 96, 96, 255}});
+}
+
+ButtonAction LevelFinishedMenu::show(SDL_Window *window, SDL_Renderer *renderer, int width,
+                                     int height, bool transparent) {
+    LevelFinishedMenu menu;
+    return menu.run(window, renderer, width, height, transparent);
+}


### PR DESCRIPTION
## Summary
- show a blinking "LEVEL FINISHED" section in the top HUD once the quota is met
- track quota completion in the render state and open the Level Finished menu when pressing Enter
- add a LevelFinishedMenu overlay with continue, leaderboard, settings, and quit options

## Testing
- cmake -S . -B build *(fails: could not locate SDL2Config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68cfb901cf84832f9143e47d152bbda8