### PR TITLE
Standardize menu button sizes

### DIFF
--- a/inc/AMenu.hpp
+++ b/inc/AMenu.hpp
@@ -16,6 +16,12 @@ protected:
     int buttons_bottom_margin;
     int title_top_margin;
 
+    virtual int button_rows() const;
+    virtual void layout_buttons(std::vector<Button> &buttons, int width, int height,
+                                float scale_factor, int button_width, int button_height,
+                                int button_gap, int start_y, int center_x);
+    virtual void adjust_layout_metrics(float scale_factor, int &button_width,
+                                       int &button_height, int &button_gap);
     virtual void draw_content(SDL_Renderer *renderer, int width, int height, int scale,
                               int title_scale, int title_x, int title_y, int title_height,
                               int title_gap, int buttons_start_y);

--- a/inc/Button.hpp
+++ b/inc/Button.hpp
@@ -11,6 +11,7 @@ enum class ButtonAction {
     Settings,
     Leaderboard,
     HowToPlay,
+    Tutorial,
     Back,
     Quit
 };
@@ -21,6 +22,7 @@ constexpr SDL_Color PastelBlue{96, 128, 255, 255};
 constexpr SDL_Color PastelYellow{255, 224, 128, 255};
 constexpr SDL_Color PastelRed{255, 96, 96, 255};
 constexpr SDL_Color PastelGray{176, 176, 176, 255};
+constexpr SDL_Color PastelPurple{192, 160, 255, 255};
 } // namespace MenuColors
 
 // Represents an interactive button in a menu

--- a/inc/MainMenu.hpp
+++ b/inc/MainMenu.hpp
@@ -3,6 +3,14 @@
 
 // Main menu displayed before starting the game
 class MainMenu : public AMenu {
+protected:
+    int button_rows() const override;
+    void layout_buttons(std::vector<Button> &buttons, int width, int height,
+                        float scale_factor, int button_width, int button_height,
+                        int button_gap, int start_y, int center_x) override;
+    void adjust_layout_metrics(float scale_factor, int &button_width, int &button_height,
+                               int &button_gap) override;
+
 public:
     MainMenu();
     static bool show(int width, int height);

--- a/inc/PauseMenu.hpp
+++ b/inc/PauseMenu.hpp
@@ -6,6 +6,14 @@ struct SDL_Renderer;
 
 // Menu shown when the game is paused
 class PauseMenu : public AMenu {
+protected:
+    int button_rows() const override;
+    void layout_buttons(std::vector<Button> &buttons, int width, int height,
+                        float scale_factor, int button_width, int button_height,
+                        int button_gap, int start_y, int center_x) override;
+    void adjust_layout_metrics(float scale_factor, int &button_width, int &button_height,
+                               int &button_gap) override;
+
 public:
     PauseMenu();
     static bool show(SDL_Window *window, SDL_Renderer *renderer, int width, int height);

--- a/src/AMenu.cpp
+++ b/src/AMenu.cpp
@@ -9,6 +9,29 @@ AMenu::AMenu(const std::string &t)
     : title(t), buttons_align_bottom(false), buttons_bottom_margin(-1),
       title_top_margin(-1) {}
 
+int AMenu::button_rows() const { return static_cast<int>(buttons.size()); }
+
+void AMenu::layout_buttons(std::vector<Button> &buttons_list, int width, int height,
+                           float scale_factor, int button_width, int button_height,
+                           int button_gap, int start_y, int center_x) {
+    (void)width;
+    (void)height;
+    (void)scale_factor;
+    for (std::size_t i = 0; i < buttons_list.size(); ++i) {
+        buttons_list[i].rect = {center_x,
+                                start_y + static_cast<int>(i) * (button_height + button_gap),
+                                button_width, button_height};
+    }
+}
+
+void AMenu::adjust_layout_metrics(float scale_factor, int &button_width, int &button_height,
+                                  int &button_gap) {
+    (void)scale_factor;
+    (void)button_width;
+    (void)button_height;
+    (void)button_gap;
+}
+
 ButtonAction AMenu::run(SDL_Window *window, SDL_Renderer *renderer, int width, int height,
                        bool transparent) {
     bool running = true;
@@ -35,6 +58,7 @@ ButtonAction AMenu::run(SDL_Window *window, SDL_Renderer *renderer, int width, i
         int button_width = static_cast<int>(300 * scale_factor);
         int button_height = static_cast<int>(100 * scale_factor);
         int button_gap = static_cast<int>(10 * scale_factor);
+        adjust_layout_metrics(scale_factor, button_width, button_height, button_gap);
         int scale = static_cast<int>(4 * scale_factor);
         if (scale < 1)
             scale = 1;
@@ -55,9 +79,9 @@ ButtonAction AMenu::run(SDL_Window *window, SDL_Renderer *renderer, int width, i
             corner_margin = 10;
 
         int total_buttons_height = 0;
-        if (!buttons.empty()) {
-            total_buttons_height = static_cast<int>(buttons.size()) * button_height +
-                                   (static_cast<int>(buttons.size()) - 1) * button_gap;
+        int rows = button_rows();
+        if (rows > 0) {
+            total_buttons_height = rows * button_height + (rows - 1) * button_gap;
         }
         int title_height = 7 * title_scale;
         int top_margin = (height - title_height - title_gap - total_buttons_height) / 2;
@@ -82,11 +106,8 @@ ButtonAction AMenu::run(SDL_Window *window, SDL_Renderer *renderer, int width, i
             if (start_y < min_start)
                 start_y = min_start;
         }
-        for (std::size_t i = 0; i < buttons.size(); ++i) {
-            buttons[i].rect = {center_x,
-                               start_y + static_cast<int>(i) * (button_height + button_gap),
-                               button_width, button_height};
-        }
+        layout_buttons(buttons, width, height, scale_factor, button_width, button_height,
+                       button_gap, start_y, center_x);
 
         for (std::size_t i = 0; i < corner_buttons.size(); ++i) {
             int offset = static_cast<int>(i) * (corner_button_height + corner_margin);
@@ -136,6 +157,8 @@ ButtonAction AMenu::run(SDL_Window *window, SDL_Renderer *renderer, int width, i
                     } else if (btn.action == ButtonAction::HowToPlay) {
                         present_background();
                         HowToPlayMenu::show(window, renderer, width, height, transparent);
+                    } else if (btn.action == ButtonAction::Tutorial) {
+                        // Tutorial button is a placeholder and does not trigger an action yet.
                     } else {
                         result = btn.action;
                         running = false;

--- a/src/MainMenu.cpp
+++ b/src/MainMenu.cpp
@@ -1,14 +1,76 @@
 #include "MainMenu.hpp"
 #include <SDL.h>
+#include <algorithm>
 
 MainMenu::MainMenu() : AMenu("MINIRT THE GAME") {
     buttons.push_back(Button{"PLAY", ButtonAction::Play, MenuColors::PastelGreen});
     buttons.push_back(
+        Button{"TUTORIAL", ButtonAction::Tutorial, MenuColors::PastelPurple});
+    buttons.push_back(
+        Button{"HOW TO PLAY", ButtonAction::HowToPlay, MenuColors::PastelYellow});
+    buttons.push_back(
         Button{"LEADERBOARD", ButtonAction::Leaderboard, MenuColors::PastelBlue});
-    buttons.push_back(Button{"SETTINGS", ButtonAction::Settings, MenuColors::PastelYellow});
+    buttons.push_back(
+        Button{"SETTINGS", ButtonAction::Settings, MenuColors::PastelGray});
     buttons.push_back(Button{"QUIT", ButtonAction::Quit, MenuColors::PastelRed});
-    corner_buttons.push_back(
-        Button{"HOW TO PLAY", ButtonAction::HowToPlay, MenuColors::PastelGray});
+}
+
+int MainMenu::button_rows() const {
+    if (buttons.empty())
+        return 0;
+    return static_cast<int>((buttons.size() + 1) / 2);
+}
+
+void MainMenu::adjust_layout_metrics(float scale_factor, int &button_width,
+                                     int &button_height, int &button_gap) {
+    (void)scale_factor;
+    button_width = static_cast<int>(button_width * 0.9f);
+    button_height = static_cast<int>(button_height * 0.85f);
+    button_gap = static_cast<int>(button_gap * 0.7f);
+    if (button_width < 200)
+        button_width = 200;
+    if (button_height < 70)
+        button_height = 70;
+    if (button_gap < 6)
+        button_gap = 6;
+}
+
+void MainMenu::layout_buttons(std::vector<Button> &buttons_list, int width, int height,
+                              float scale_factor, int button_width, int button_height,
+                              int button_gap, int start_y, int center_x) {
+    (void)height;
+    (void)scale_factor;
+    (void)center_x;
+    if (buttons_list.size() < 2) {
+        AMenu::layout_buttons(buttons_list, width, height, scale_factor, button_width,
+                              button_height, button_gap, start_y, center_x);
+        return;
+    }
+
+    int rows = button_rows();
+    int left_column_width = button_width;
+    int right_column_width = button_width;
+    int column_gap = std::max(button_gap, button_width / 10);
+    if (column_gap < 1)
+        column_gap = 1;
+    int total_width = left_column_width + column_gap + right_column_width;
+    int left_x = width / 2 - total_width / 2;
+    int right_x = left_x + left_column_width + column_gap;
+    int vertical_gap = button_gap;
+    auto set_button = [&](std::size_t index, int x, int y, int w) {
+        if (index >= buttons_list.size())
+            return;
+        buttons_list[index].rect = {x, y, w, button_height};
+    };
+
+    for (int row = 0; row < rows; ++row) {
+        int y = start_y + row * (button_height + vertical_gap);
+        std::size_t left_index = static_cast<std::size_t>(row * 2);
+        std::size_t right_index = left_index + 1;
+        set_button(left_index, left_x, y, left_column_width);
+        if (right_index < buttons_list.size())
+            set_button(right_index, right_x, y, right_column_width);
+    }
 }
 
 bool MainMenu::show(int width, int height) {

--- a/src/PauseMenu.cpp
+++ b/src/PauseMenu.cpp
@@ -1,14 +1,73 @@
 #include "PauseMenu.hpp"
+#include <algorithm>
 
 PauseMenu::PauseMenu() : AMenu("PAUSE") {
     title_colors.assign(title.size(), SDL_Color{255, 255, 255, 255});
     buttons.push_back(Button{"RESUME", ButtonAction::Resume, MenuColors::PastelGreen});
     buttons.push_back(
+        Button{"HOW TO PLAY", ButtonAction::HowToPlay, MenuColors::PastelYellow});
+    buttons.push_back(
         Button{"LEADERBOARD", ButtonAction::Leaderboard, MenuColors::PastelBlue});
-    buttons.push_back(Button{"SETTINGS", ButtonAction::Settings, MenuColors::PastelYellow});
+    buttons.push_back(Button{"SETTINGS", ButtonAction::Settings, MenuColors::PastelGray});
     buttons.push_back(Button{"QUIT", ButtonAction::Quit, MenuColors::PastelRed});
-    corner_buttons.push_back(
-        Button{"HOW TO PLAY", ButtonAction::HowToPlay, MenuColors::PastelGray});
+}
+
+int PauseMenu::button_rows() const {
+    if (buttons.empty())
+        return 0;
+    return static_cast<int>((buttons.size() + 1) / 2);
+}
+
+void PauseMenu::adjust_layout_metrics(float scale_factor, int &button_width,
+                                      int &button_height, int &button_gap) {
+    (void)scale_factor;
+    button_width = static_cast<int>(button_width * 0.9f);
+    button_height = static_cast<int>(button_height * 0.85f);
+    button_gap = static_cast<int>(button_gap * 0.7f);
+    if (button_width < 200)
+        button_width = 200;
+    if (button_height < 70)
+        button_height = 70;
+    if (button_gap < 6)
+        button_gap = 6;
+}
+
+void PauseMenu::layout_buttons(std::vector<Button> &buttons_list, int width, int height,
+                               float scale_factor, int button_width, int button_height,
+                               int button_gap, int start_y, int center_x) {
+    (void)height;
+    (void)scale_factor;
+    (void)center_x;
+    if (buttons_list.size() < 2) {
+        AMenu::layout_buttons(buttons_list, width, height, scale_factor, button_width,
+                              button_height, button_gap, start_y, center_x);
+        return;
+    }
+
+    int rows = button_rows();
+    int left_column_width = button_width;
+    int right_column_width = button_width;
+    int column_gap = std::max(button_gap, button_width / 10);
+    if (column_gap < 1)
+        column_gap = 1;
+    int total_width = left_column_width + column_gap + right_column_width;
+    int left_x = width / 2 - total_width / 2;
+    int right_x = left_x + left_column_width + column_gap;
+    int vertical_gap = button_gap;
+    auto set_button = [&](std::size_t index, int x, int y, int w) {
+        if (index >= buttons_list.size())
+            return;
+        buttons_list[index].rect = {x, y, w, button_height};
+    };
+
+    for (int row = 0; row < rows; ++row) {
+        int y = start_y + row * (button_height + vertical_gap);
+        std::size_t left_index = static_cast<std::size_t>(row * 2);
+        std::size_t right_index = left_index + 1;
+        set_button(left_index, left_x, y, left_column_width);
+        if (right_index < buttons_list.size())
+            set_button(right_index, right_x, y, right_column_width);
+    }
 }
 
 bool PauseMenu::show(SDL_Window *window, SDL_Renderer *renderer, int width, int height) {


### PR DESCRIPTION
## Summary
- give the Tutorial button the same width as the rest of the main menu grid
- remove the placeholder Tutorial option from the pause menu while keeping its two-column layout consistent

## Testing
- cmake -S . -B build *(fails: missing SDL2 development package in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3b05ba0f0832f9ac0cf3fd6616148