### PR TITLE
Add tutorial prompt parsing and HUD display

### DIFF
--- a/inc/Parser.hpp
+++ b/inc/Parser.hpp
@@ -8,8 +8,9 @@
 class Parser
 {
 	public:
-	static bool parse_rt_file(const std::string &path, Scene &outScene,
-							  Camera &outCamera, int width, int height);
+        static bool parse_rt_file(const std::string &path, Scene &outScene,
+                                                          Camera &outCamera, int width, int height,
+                                                          bool tutorial_mode = false);
 
 	static const std::vector<Material> &get_materials();
 	private:

--- a/inc/Scene.hpp
+++ b/inc/Scene.hpp
@@ -4,6 +4,7 @@
 #include "light.hpp"
 #include "material.hpp"
 #include <memory>
+#include <string>
 #include <vector>
 #include <unordered_map>
 
@@ -19,6 +20,7 @@ class Scene
         std::shared_ptr<Hittable> accel;
         bool target_required = false;
         double minimal_score = 0.0;
+        std::vector<std::string> tutorial_prompts;
 
         // Update beam objects and associated lights in the scene.
         void update_beams(const std::vector<Material> &materials);

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -30,7 +30,8 @@ bool run_application(const std::string &scene_path, int width, int height,
 	Camera camera({0, 0, -10}, {0, 0, 0}, 60.0,
 				  static_cast<double>(width) / static_cast<double>(height));
 	bool parsed;
-	parsed = Parser::parse_rt_file(scene_path, scene, camera, width, height);
+        parsed = Parser::parse_rt_file(scene_path, scene, camera, width, height,
+                                                               tutorial_mode);
         if (!parsed)
         {
                 std::cerr << "Failed to parse scene: " << scene_path << "\n";


### PR DESCRIPTION
## Summary
- support parsing tutorial prompt sections and store them on the scene when tutorial mode is enabled
- propagate tutorial mode into the renderer so tutorial prompts can be cycled with Enter while tracking progress
- render tutorial prompts in the HUD with wrapped text and progress details alongside existing controls

## Testing
- cmake -S . -B build *(fails: missing SDL2 development package in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d6752a4bf8832f98fc373b0d7c9948