### PR TITLE
Add tutorial prompt support

### DIFF
--- a/inc/Scene.hpp
+++ b/inc/Scene.hpp
@@ -4,6 +4,7 @@
 #include "light.hpp"
 #include "material.hpp"
 #include <memory>
+#include <string>
 #include <vector>
 #include <unordered_map>
 
@@ -19,6 +20,7 @@ class Scene
         std::shared_ptr<Hittable> accel;
         bool target_required = false;
         double minimal_score = 0.0;
+        std::vector<std::string> tutorial_prompts;
 
         // Update beam objects and associated lights in the scene.
         void update_beams(const std::vector<Material> &materials);


### PR DESCRIPTION
## Summary
- parse tutorial scene [prompts] sections and persist the ordered entries in the scene data
- expose tutorial prompts to the renderer and cycle them on Enter while in tutorial mode
- show the active tutorial prompt in the HUD and reset prompts when scenes reload or advance

## Testing
- cmake -S . -B build *(fails: missing SDL2 development package in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d6752a4bf8832f98fc373b0d7c9948