### PR TITLE
Allow returning to menu while preserving level progress

### DIFF
--- a/inc/Application.hpp
+++ b/inc/Application.hpp
@@ -2,6 +2,8 @@
 
 #include <string>
 
+struct SessionProgress;
+
 /**
  * Loads scene, prepares renderer and displays window.
  *
@@ -9,6 +11,8 @@
  * @param width Desired window width.
  * @param height Desired window height.
  * @param quality Render quality (L/M/H).
+ * @param progress Persistent data shared between sessions.
  */
 bool run_application(const std::string &scene_path, int width, int height,
-                                        char quality, bool tutorial_mode);
+                                        char quality, bool tutorial_mode,
+                                        SessionProgress &progress);

--- a/inc/Renderer.hpp
+++ b/inc/Renderer.hpp
@@ -18,15 +18,26 @@ class RenderSettings
 	float downscale = 1.0f; // 1.0 => full res, 1.5 => medium, 2.0 => low
 };
 
+struct SessionProgress
+{
+        bool has_progress = false;
+        bool tutorial_mode = false;
+        std::string next_scene_path;
+        double cumulative_score = 0.0;
+        int completed_levels = 0;
+        std::string player_name;
+};
+
 class Renderer
 {
-	public:
-	Renderer(Scene &s, Camera &c);
+        public:
+        Renderer(Scene &s, Camera &c);
         void render_ppm(const std::string &path, const std::vector<Material> &mats,
                                         const RenderSettings &rset);
         bool render_window(std::vector<Material> &mats, const RenderSettings &rset,
-                                           const std::string &scene_path, bool tutorial_mode);
-		struct RenderState;
+                                           const std::string &scene_path, bool tutorial_mode,
+                                           SessionProgress *progress);
+                struct RenderState;
         private:
         void mark_scene_dirty(RenderState &st);
         bool init_sdl(SDL_Window *&win, SDL_Renderer *&ren, SDL_Texture *&tex,

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -3,15 +3,17 @@
 #include "Parser.hpp"
 #include "Renderer.hpp"
 #include "Scene.hpp"
+#include <filesystem>
 #include <iostream>
 #include <thread>
 
 // Launch the rendering pipeline and display the interactive window.
 bool run_application(const std::string &scene_path, int width, int height,
-                                        char quality, bool tutorial_mode)
+                                        char quality, bool tutorial_mode,
+                                        SessionProgress &progress)
 {
-	unsigned int thread_count;
-	thread_count = std::thread::hardware_concurrency();
+        unsigned int thread_count;
+        thread_count = std::thread::hardware_concurrency();
 	if (thread_count == 0)
 	{
 		thread_count = 8;
@@ -29,24 +31,26 @@ bool run_application(const std::string &scene_path, int width, int height,
 	Scene scene;
 	Camera camera({0, 0, -10}, {0, 0, 0}, 60.0,
 				  static_cast<double>(width) / static_cast<double>(height));
-	bool parsed;
-	parsed = Parser::parse_rt_file(scene_path, scene, camera, width, height);
+        bool parsed;
+        parsed = Parser::parse_rt_file(scene_path, scene, camera, width, height);
         if (!parsed)
         {
                 std::cerr << "Failed to parse scene: " << scene_path << "\n";
                 return false;
         }
-	std::vector<Material> materials;
-	materials = Parser::get_materials();
+        std::vector<Material> materials;
+        materials = Parser::get_materials();
 
-	scene.update_beams(materials);
-	scene.build_bvh();
-	RenderSettings render_settings;
-	render_settings.width = width;
-	render_settings.height = height;
-	render_settings.threads = thread_count;
-	render_settings.downscale = downscale;
-	Renderer renderer(scene, camera);
+        scene.update_beams(materials);
+        scene.build_bvh();
+        RenderSettings render_settings;
+        render_settings.width = width;
+        render_settings.height = height;
+        render_settings.threads = thread_count;
+        render_settings.downscale = downscale;
+        Renderer renderer(scene, camera);
+        progress.tutorial_mode = tutorial_mode;
+        progress.next_scene_path = std::filesystem::absolute(scene_path).string();
         return renderer.render_window(materials, render_settings, scene_path,
-                                                              tutorial_mode);
+                                                              tutorial_mode, &progress);
 }

--- a/src/LevelFinishedMenu.cpp
+++ b/src/LevelFinishedMenu.cpp
@@ -253,7 +253,8 @@ ButtonAction LevelFinishedMenu::run(SDL_Window *window, SDL_Renderer *renderer, 
     Button next_button{"NEXT LEVEL", ButtonAction::NextLevel, SDL_Color{96, 255, 128, 255}};
     Button leaderboard_button{"LEADERBOARD", ButtonAction::Leaderboard,
                               SDL_Color{96, 128, 255, 255}};
-    Button quit_button{"QUIT", ButtonAction::Quit, SDL_Color{255, 96, 96, 255}};
+    Button back_button{"BACK TO MENU", ButtonAction::BackToMenu,
+                       SDL_Color{255, 96, 96, 255}};
     SDL_Color submit_idle_color{64, 160, 96, 220};
     Button submit_button{"SUBMIT", ButtonAction::None, SDL_Color{96, 255, 128, 255}};
 
@@ -299,7 +300,7 @@ ButtonAction LevelFinishedMenu::run(SDL_Window *window, SDL_Renderer *renderer, 
         int bottom_total_width = button_width * 2 + button_gap;
         int bottom_start_x = width / 2 - bottom_total_width / 2;
         leaderboard_button.rect = {bottom_start_x, bottom_y, button_width, button_height};
-        quit_button.rect = {bottom_start_x + button_width + button_gap, bottom_y, button_width,
+        back_button.rect = {bottom_start_x + button_width + button_gap, bottom_y, button_width,
                             button_height};
 
         SDL_Rect name_rect{0, 0, 0, 0};
@@ -396,9 +397,9 @@ ButtonAction LevelFinishedMenu::run(SDL_Window *window, SDL_Renderer *renderer, 
                     LeaderboardMenu::show(window, renderer, width, height, transparent);
                     if (was_active && allow_name_input)
                         SDL_StartTextInput();
-                } else if (point_in_rect(quit_button.rect, mx, my)) {
+                } else if (point_in_rect(back_button.rect, mx, my)) {
                     running = false;
-                    result = ButtonAction::Quit;
+                    result = ButtonAction::BackToMenu;
                 } else if (allow_name_input && point_in_rect(name_rect, mx, my)) {
                     name_field_active = true;
                     if (!SDL_IsTextInputActive())
@@ -522,7 +523,7 @@ ButtonAction LevelFinishedMenu::run(SDL_Window *window, SDL_Renderer *renderer, 
         if (stats_.has_next_level)
             draw_button(next_button, true, false, SDL_Color{}, false);
         draw_button(leaderboard_button, true, false, SDL_Color{}, false);
-        draw_button(quit_button, true, false, SDL_Color{}, false);
+        draw_button(back_button, true, false, SDL_Color{}, false);
 
         if (show_name_input) {
             SDL_Color bg_color{20, 20, 20, 220};


### PR DESCRIPTION
## Summary
- replace the Level Finished screen "QUIT" button with a "BACK TO MENU" action
- add a SessionProgress structure that run_application, Renderer, and main use to persist cumulative score, name, and next level information between sessions
- update the renderer to record completed levels and carry scores forward when returning to the menu

## Testing
- cmake -S . -B build *(fails: missing SDL2 development files in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dae5e7b36c832fa00c8a874a417cef